### PR TITLE
Suggested changes to RAP pages on the analysts guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,25 +1,47 @@
+---
+editor: 
+  markdown: 
+    wrap: 72
+---
+
 # Contributing to the Analyst's Guide
 
-Thank you for investing your time in contributing to the analyst's guide! All contributions are very welcome - we want this to be a useful resource for the whole analytical community in DfE :sparkles:.
+Thank you for investing your time in contributing to the analyst's
+guide! All contributions are very welcome - we want this to be a useful
+resource for the whole analytical community in DfE :sparkles:.
 
-Read our [Code of Conduct](./CODE_OF_CONDUCT.md) to keep our community approachable and respectable.
+Read our [Code of Conduct](./CODE_OF_CONDUCT.md) to keep our community
+approachable and respectable.
 
-The main branch of the site is protected and can only be updated via pull requests. All pull requests must be approved by a repository admin before merging.
+The main branch of the site is protected and can only be updated via
+pull requests. All pull requests must be approved by a repository admin
+before merging.
 
-In this guide you will get an overview of the contribution workflow from opening an issue, creating a PR, reviewing, and merging the PR.
+In this guide you will get an overview of the contribution workflow from
+opening an issue, creating a PR, reviewing, and merging the PR.
 
 ## New contributor guide
 
-To get an overview of the project, read the [README](README.md). Here are some resources to help you get started with open source contributions:
+To get an overview of the project, read the [README](README.md). Here
+are some resources to help you get started with open source
+contributions:
 
-- [Finding ways to contribute to open source on GitHub](https://docs.github.com/en/get-started/exploring-projects-on-github/finding-ways-to-contribute-to-open-source-on-github)
-- [Set up Git](https://docs.github.com/en/get-started/quickstart/set-up-git)
-- [GitHub flow](https://docs.github.com/en/get-started/quickstart/github-flow)
-- [Collaborating with pull requests](https://docs.github.com/en/github/collaborating-with-pull-requests)
+-   [Finding ways to contribute to open source on
+    GitHub](https://docs.github.com/en/get-started/exploring-projects-on-github/finding-ways-to-contribute-to-open-source-on-github)
+-   [Set up
+    Git](https://docs.github.com/en/get-started/quickstart/set-up-git)
+-   [GitHub
+    flow](https://docs.github.com/en/get-started/quickstart/github-flow)
+-   [Collaborating with pull
+    requests](https://docs.github.com/en/github/collaborating-with-pull-requests)
 
 ### Quarto guidance
-For more information specific to how a quarto site works, and for examples of what is possible within a static quarto site, see the main [Quarto website](https://quarto.org/).
 
+For more information specific to how a quarto site works, and for
+examples of what is possible within a static quarto site, see the main
+[Quarto website](https://quarto.org/).
+
+```{=html}
 <!-- TODO: add more details on
 
 - adding images (in the right folder, code to do so)
@@ -30,52 +52,96 @@ For more information specific to how a quarto site works, and for examples of wh
 - building locally before raising a pull request
 
 -->
+```
+#### Changing the appearance of code blocks
+
+You can modify the `highlight-style` element in the `quarto.yml` file to
+change the display of code blocks using predefined themes. This will
+change the appearance of all code snippets across the entire Analysts'
+guide. The current theme is set to "printing" but there is a list of
+other available themes [on the Quarto
+website](https://quarto.org/docs/output-formats/html-code.html#highlighting).
+
+Some things to be aware of before you make changes:
+
+-   Some of the themes are adaptive, meaning that if you change the site
+    view from dark mode to light mode then the theme will also change
+    accordingly.
+
+-   The appearance of code snippets will only change if the language
+    (e.g. R, Python) is defined at the start of the snippet (e.g.
+    ```` ``` {r connection_example, eval=FALSE} ````). Including
+    `eval=FALSE` stops your code snippet from actually running. If no
+    language is defined, the snippet appearance will need to be modified
+    manually and this can cause some issues.
 
 ### Issues
 
 #### Create a new issue
 
-If you spot a problem with the site, [search if an issue already exists](https://docs.github.com/en/github/searching-for-information-on-github/searching-on-github/searching-issues-and-pull-requests#search-by-the-title-body-or-comments). If a related issue doesn't exist, you can open a new issue using a relevant [issue form](https://github.com/dfe-analytical-services/analysts-guide/issues/new/choose).
+If you spot a problem with the site, [search if an issue already
+exists](https://docs.github.com/en/github/searching-for-information-on-github/searching-on-github/searching-issues-and-pull-requests#search-by-the-title-body-or-comments).
+If a related issue doesn't exist, you can open a new issue using a
+relevant [issue
+form](https://github.com/dfe-analytical-services/analysts-guide/issues/new/choose).
 
 #### Solve an issue
 
-Scan through our [existing issues](https://github.com/dfe-analytical-services/analysts-guide/issues) to find one that interests you. If you find an issue to work on, you are welcome to open a PR with a fix.
+Scan through our [existing
+issues](https://github.com/dfe-analytical-services/analysts-guide/issues)
+to find one that interests you. If you find an issue to work on, you are
+welcome to open a PR with a fix.
 
 ### Make Changes
 
-Key things to remember when making or proposing changes:
-- Where guidance already exists elsewhere it should be linked to rather than duplicated
-- When adding images, save them in the /images folder
-- When adding files for download, save them in the /resources folder
-- Don't commit rendered .html files for pages
-- If your changes remove or edit a pre-existing anchor link, consider how that will be redirected for users who may have bookmarked it
+Key things to remember when making or proposing changes: - Where
+guidance already exists elsewhere it should be linked to rather than
+duplicated - When adding images, save them in the /images folder - When
+adding files for download, save them in the /resources folder - Don't
+commit rendered .html files for pages - If your changes remove or edit a
+pre-existing anchor link, consider how that will be redirected for users
+who may have bookmarked it
 
 #### Make changes in the UI
 
-Click **Edit this page** at the bottom of the right hand table of contents of any page to make small changes such as a typo, sentence fix, or a broken link. This takes you to the `.Qmd` file where you can make your changes and [create a pull request](#pull-request) for a review.
+Click **Edit this page** at the bottom of the right hand table of
+contents of any page to make small changes such as a typo, sentence fix,
+or a broken link. This takes you to the `.Qmd` file where you can make
+your changes and [create a pull request](#pull-request) for a review.
 
 #### Make changes locally
 
-1. Clone or fork the repository.
+1.  Clone or fork the repository.
 
-2. Open the repository in your editor of choice, e.g. R Studio.
+2.  Open the repository in your editor of choice, e.g. R Studio.
 
-3. Create a working branch and start with your changes!
+3.  Create a working branch and start with your changes!
 
-4. Commit and push the changes to your working branch.
+4.  Commit and push the changes to your working branch.
 
-### Pull Request
+### Pull Request {#pull-request}
 
 All pull requests should be made against the main branch.
 
-When you're finished with the changes, create a pull request, also known as a PR.
-- Don't forget to [link PR to issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) if you are solving one.
+When you're finished with the changes, create a pull request, also known
+as a PR. - Don't forget to [link PR to
+issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
+if you are solving one.
 
-Once you submit your PR, a repository admin will review your proposal. We may ask questions or request additional information.
-- We may ask for changes to be made before a PR can be merged, either using [suggested changes](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request) or pull request comments. You can apply suggested changes directly through the UI. You can make any other changes and then commit them to your branch.
-- As you update your PR and apply changes, mark each conversation as [resolved](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/commenting-on-a-pull-request#resolving-conversations).
-- If you run into any merge issues, checkout this [Git tutorial](https://github.com/skills/resolve-merge-conflicts) to help you resolve merge conflicts and other issues.
+Once you submit your PR, a repository admin will review your proposal.
+We may ask questions or request additional information. - We may ask for
+changes to be made before a PR can be merged, either using [suggested
+changes](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request)
+or pull request comments. You can apply suggested changes directly
+through the UI. You can make any other changes and then commit them to
+your branch. - As you update your PR and apply changes, mark each
+conversation as
+[resolved](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/commenting-on-a-pull-request#resolving-conversations). -
+If you run into any merge issues, checkout this [Git
+tutorial](https://github.com/skills/resolve-merge-conflicts) to help you
+resolve merge conflicts and other issues.
 
-## Support 
+## Support
 
-If you need any assistance at all, please contact [statistics.development@education.gov.uk](mailto:statistics.development@education.gov.uk).
+If you need any assistance at all, please contact
+[statistics.development\@education.gov.uk](mailto:statistics.development@education.gov.uk).

--- a/RAP/rap-expectations.qmd
+++ b/RAP/rap-expectations.qmd
@@ -12,7 +12,7 @@ title: "RAP expectations"
 
 As government analysts working with statistics, we are required to ensure that our analysis is reproducible, transparent, and robust, using coding and code management best practices (source [GSG competency framework](https://analysisfunction.civilservice.gov.uk/policy-store/competency-framework-for-the-government-statistician-group-gsg/)). Reproducible Analytical Pipelines (RAP) are a cross-government requirement to help analysts adopt best practices.
 
-We expect any analyst working in statistics production to know and be able to implement RAP principles, using the recommended tools to meet at least good and great practice. You can see examples of good, great, and best practice on our [RAP in statistics guidance page](../RAP/rap-statistics.html).
+We expect any analyst to know and be able to implement RAP principles, using the recommended tools to meet at least good and great practice. You can see examples of good, great, and best practice on our [RAP in statistics guidance page](../RAP/rap-statistics.html).
 
 We expect managers of analysts working in statistics production to support and prioritise the development required to build the skills needed to implement RAP using the recommended tools. Managers should ensure that the processes for any publications they own meet at least good and great practice.
 

--- a/RAP/rap-expectations.qmd
+++ b/RAP/rap-expectations.qmd
@@ -10,15 +10,13 @@ title: "RAP expectations"
 
 ---
 
-As government analysts working with statistics, we are required to ensure that our analysis is reproducible, transparent, and robust, using coding and code management best practices (source [GSG competency framework](https://analysisfunction.civilservice.gov.uk/policy-store/competency-framework-for-the-government-statistician-group-gsg/)). RAP is a cross-government requirement to help analysts adopt best practices.
+As government analysts working with statistics, we are required to ensure that our analysis is reproducible, transparent, and robust, using coding and code management best practices (source [GSG competency framework](https://analysisfunction.civilservice.gov.uk/policy-store/competency-framework-for-the-government-statistician-group-gsg/)). Reproducible Analytical Pipelines (RAP) are a cross-government requirement to help analysts adopt best practices.
 
-We expect any analyst working in statistics production to know and be able to implement RAP principles, using the recommended tools to meet at least good and great practice. 
+We expect any analyst working in statistics production to know and be able to implement RAP principles, using the recommended tools to meet at least good and great practice. You can see examples of good, great, and best practice on our [RAP in statistics guidance page](../RAP/rap-statistics.html).
 
 We expect managers of analysts working in statistics production to support and prioritise the development required to build the skills needed to implement RAP using the recommended tools. Managers should ensure that the processes for any publications they own meet at least good and great practice.
 
-More information, including definitions of the different levels of good, great, and best practice is on our [RAP in statistics guidance page](../RAP/rap-statistics.html).
-
-The [cross-government RAP strategy](https://analysisfunction.civilservice.gov.uk/policy-store/reproducible-analytical-pipelines-strategy/) states a number of explicit expectations for analysts involved in the process, which are detailed in the following sections: [analyst leaders](#analyst-leaders), [analyst managers](#analyst-managers) and [analysts](#analysts).
+Although RAP is often discussed in the context of statistics production, RAP principles can also be applied to other analysis work. The [cross-government RAP strategy](https://analysisfunction.civilservice.gov.uk/policy-store/reproducible-analytical-pipelines-strategy/) states a number of explicit expectations for analysts involved in the process, which are detailed in the following sections: [analyst leaders](#analyst-leaders), [analyst managers](#analyst-managers) and [analysts](#analysts).
 
 ---
 

--- a/RAP/rap-faq.qmd
+++ b/RAP/rap-faq.qmd
@@ -28,7 +28,7 @@ No. Reproducible Analytical Pipelines (RAPs) are automated statistical and analy
 
 Doing RAP is doing analysis using the best methods available to us, which is an expectation of the statistics code of practice.
 
-The tools we recommend for statistics production RAP are SQL, Git and R. Other suitable alternatives that allow you to meet the core principles can also be used, but you should check this with the Statistics Development Team first. Ideally any tools used would be open source, Python is a good example of a tool that would also be well suited, though is less widely used in DfE and has a steeper learning curve than R.
+The tools we recommend for statistics production RAP are SQL, Git and R. Other suitable alternatives that allow you to meet the core principles can also be used, but you should check this with the Statistics Development Team first. Ideally any tools used would be open source. Python is a good example of a tool that would also be well suited, though is less widely used in DfE and has a steeper learning curve than R.
 
 Using R for parts of the process does get you close to a lot of the RAP principles with little effort, which is why we recommend it as one of the tools you should use.
 
@@ -44,7 +44,7 @@ No -- RAP is a cross government strategy, and all departments are expected to us
 
 Here is a great [blog post from NHS digital on 'Why we're getting our data teams to RAP'](https://digital.nhs.uk/blog/data-points-blog/2023/why-were-getting-our-data-teams-to-rap).
 
-RAP is also a strategic objective of [Analysis function strategy for 22-25](https://analysisfunction.civilservice.gov.uk/about-us/analysis-function-strategy/#strategic-objective-2-promoting-impactful-and-efficient-analysis-through-innovative-tools-and-cutting-edge-techniques):
+RAP is also a strategic objective of [Analysis Function strategy for 22-25](https://analysisfunction.civilservice.gov.uk/about-us/analysis-function-strategy/#strategic-objective-2-promoting-impactful-and-efficient-analysis-through-innovative-tools-and-cutting-edge-techniques):
 
 > delivering the [Reproducible Analytical Pipelines (RAP) Strategy](https://analysisfunction.civilservice.gov.uk/policy-store/reproducible-analytical-pipelines-strategy/) and action plan to embed RAP across government, ensuring our processes are automated, efficient, and high quality which frees up resource to add value and insight in our analysis.
 
@@ -54,7 +54,7 @@ RAP is also a strategic objective of [Analysis function strategy for 22-25](http
 
 ---
 
-The levels within RAP good practice are in line with what a lot of teams are doing already, take time to understand what the different steps mean and don't panic about the quantity of them as they've intentionally been broken down into the smallest level that was sensible.
+The levels within RAP good practice are in line with what a lot of teams are doing already, take time to understand what the different steps mean and don't panic about the quantity of them as they've intentionally been broken down into the smallest level that was sensible. Ideally your work should meet as many of the RAP criteria as possible, but even the use of some RAP principles when you're just starting out are better than none. 
 
 Statistics publications are some of the most important pieces of statistics work that the department does. It's important we get that data right; RAP can help us automate the production and QA of outputs in a way that gives us the most confidence in the statistics and causes the least burden for you.
 
@@ -66,7 +66,7 @@ Statistics publications are some of the most important pieces of statistics work
 
 Not at all. When fully implemented and accompanied with the relevant skills, RAP has the opposite effect as each stage of the process is clearly written as code.
 
-We recognise there is a sizeable skill gap, and that until this is addressed there can be a risk of feeling like code is a black box. This isn't a reason to avoid RAP though, instead it's a big reason why we need to push ahead with prioritising upskilling ourselves to implement it.
+We recognise there is a sizeable skill gap, and that until this is addressed there can be a risk of feeling like code is a black box. This isn't a reason to avoid RAP though, instead it's a big reason why we need to push ahead with prioritising upskilling ourselves to implement it. An element of RAP is having documentation for your analytical processes. Having good documentation will help to support your team as they are learning new skills, particularly when you have new starters who are taking on pieces of work for the first time. 
 
 ---
 
@@ -92,7 +92,7 @@ Questions about how to get started with RAP.
 
 No. Anyone undertaking any analytical processes should now be using RAP processes, and coding is a critical analytical skill. RAP is a cross-government strategy and there is an expectation in all departments for all analysts to move to this way of working.
 
-We all must ensure that analysis is reproducible, transparent, and robust using coding and code management best practices (GSG competency framework).
+We all must ensure that analysis is reproducible, transparent, and robust using coding and code management best practices (Analysis Function competency framework).
 
 ---
 
@@ -148,7 +148,7 @@ This is highly unlikely and is more likely to be from a lack of knowledge of wha
 
 Yes. We recommend different tools for different purposes, SQL should be used for querying source data and large data processes, R should be used for more complicated data manipulation, QA, and analysis. There's a grey area in the middle where you can do some things in either tool, sometimes you'll need to test for yourself which way is faster (e.g., linking datasets or transforming tables).
 
-SQL scripts should be run in an automated way using R, instead of manually running them and copying the outputs. The difference we're talking about here is whether you process data on the database server or on the machine you're running R. A simplistic rule of thumb is do large scale processing on the database side (e.g., filtering and aggregating), and then only bring the data you need for manipulation / complicated processing into R.
+SQL scripts should be run in an automated way using R, instead of manually running them and copying the outputs. The difference we're talking about here is whether you process data on the database server or on the machine where you're running R. A simplistic rule of thumb is do large scale processing on the database side (e.g., filtering and aggregating), and then only bring the data you need for manipulation / complicated processing into R.
 
 ---
 
@@ -165,11 +165,11 @@ Questions on how to implement RAP.
 This is a misconception of our guidance that we will be clarifying and improving the phrasing of. The two steps this refers to are:
 
 -   Can the publication be reproduced using a single code script?
--   Are data files produced via single code script(s) with integrated QA?'
+-   Are data files produced via single code script(s) with integrated QA?
 
-We're not suggesting all code lives in a single script. These steps in the RAP guidance are to encourage the repository being structured so that one clicks of a button can run the entire process from the source data through to the final output in order.
+We're not suggesting all code lives in a single script. These steps in the RAP guidance are to encourage the repository being structured so that one click of a button can run the entire process from the source data through to the final output in order.
 
-This means that you should have one 'centralized' script that details all of the different scripts in your repository. This single run script then provides a single reference point for where all of your code and scripts live, and in what order they're executed, which is fantastic piece documentation to have!
+This means that you should have one 'centralized' script that details all of the different scripts in your repository. This single run script then provides a single reference point for where all of your code and scripts live, and in what order they're executed, which is a fantastic piece documentation to have!
 
 ---
 
@@ -213,7 +213,9 @@ Questions learning more about RAP and developing skills.
 
 Absolutely. Currently the best way to do this is to ask other teams to share code directly with you. If we can all make more progress with using Git, then this will make it much easier to share repositories and have code open by default for interested analysts to browse.
 
-We are also starting up a knowledge share series, so keep an eye out for that and make sure to contribute yourselves. We'd also encourage analysts to make more use of teams to post questions and ask about other people in our area doing similar types of analysis, no question is too big or too small!
+We run a regular RAP Knowledge Share series in which we share good practice and examples of work. We record each session so that you can refer back to them at a later date if you want to. Previous recordings can be found on [Sharepoint](https://educationgovuk.sharepoint.com/:f:/r/sites/lvewp00086/SSU%20%20open%20sharing/Reproducible%20Analytical%20Pipeline%20(RAP)%20resources/Knowledge-share%20series). Upcoming sessions are advertised on the DfE analysts network mailing list.
+
+We'd also encourage analysts to make more use of the RAP Community channel in the DfE Analyst Network Teams group to post questions and ask about other people doing similar types of analysis, no question is too big or too small!
 
 ---
 

--- a/RAP/rap-faq.qmd
+++ b/RAP/rap-faq.qmd
@@ -169,7 +169,7 @@ This is a misconception of our guidance that we will be clarifying and improving
 
 We're not suggesting all code lives in a single script. These steps in the RAP guidance are to encourage the repository being structured so that one click of a button can run the entire process from the source data through to the final output in order.
 
-This means that you should have one 'centralized' script that details all of the different scripts in your repository. This single run script then provides a single reference point for where all of your code and scripts live, and in what order they're executed, which is a fantastic piece documentation to have!
+This means that you should have one 'centralized' script that details all of the different scripts in your repository. This single run script then provides a single reference point for where all of your code and scripts live, and in what order they're executed, which is a fantastic piece of documentation to have!
 
 ---
 
@@ -213,7 +213,7 @@ Questions learning more about RAP and developing skills.
 
 Absolutely. Currently the best way to do this is to ask other teams to share code directly with you. If we can all make more progress with using Git, then this will make it much easier to share repositories and have code open by default for interested analysts to browse.
 
-We run a regular RAP Knowledge Share series in which we share good practice and examples of work. We record each session so that you can refer back to them at a later date if you want to. Previous recordings can be found on [Sharepoint](https://educationgovuk.sharepoint.com/:f:/r/sites/lvewp00086/SSU%20%20open%20sharing/Reproducible%20Analytical%20Pipeline%20(RAP)%20resources/Knowledge-share%20series). Upcoming sessions are advertised on the DfE analysts network mailing list.
+We run a regular RAP Knowledge Share series in which we share good practice and examples of work. We record each session so that you can refer back to them at a later date if you want to. Previous recordings can be found in our [RAP knowledge share Sharepoint folder](https://educationgovuk.sharepoint.com/:f:/r/sites/lvewp00086/SSU%20%20open%20sharing/Reproducible%20Analytical%20Pipeline%20(RAP)%20resources/Knowledge-share%20series). Upcoming sessions are advertised on the DfE analysts network mailing list.
 
 We'd also encourage analysts to make more use of the RAP Community channel in the DfE Analyst Network Teams group to post questions and ask about other people doing similar types of analysis, no question is too big or too small!
 

--- a/RAP/rap-statistics.qmd
+++ b/RAP/rap-statistics.qmd
@@ -142,7 +142,7 @@ The Statistics Development Team invites teams to take part in our partnership pr
 
 ---
 
-The first place to start for your teams RAP is to store the raw data you use to create underlying data in a Microsoft SQL Server database. This is similar to a sharepoint area or a shared folder, but it's a dedicated data storage area which allows multiple users to use the same file at once, and for you to run code against the data in one place.
+The first place to start for your teams RAP is to store the raw data you use to create underlying data in a Microsoft SQL Server database. This is similar to a Sharepoint area or a shared folder, but it's a dedicated data storage area which allows multiple users to use the same file at once, and for you to run code against the data in one place.
 
 ---
 
@@ -565,7 +565,7 @@ There is also plenty of guidance around the internet for [best practice](https:/
 
 ---
 
-If you ever find yourself writing html, or creating it through rmarkdown, you can check your html using [w3's validator](https://validator.w3.org/){target="_blank" rel="noopener noreferrer"}.
+If you ever find yourself writing HTML, or creating it through RMarkdown, you can check your HTML using [W3's validator](https://validator.w3.org/){target="_blank" rel="noopener noreferrer"}.
 
 ---
 
@@ -689,7 +689,7 @@ While peer reviewing code within the team is often practical, having external an
 
 ---
 
-## Automated quality assurance
+## Automated quality assurance (QA)
 
 
 Any data files that have been created will need to be quality assured. These checks should be automated where possible, so the computer is doing the hard work - saving us time, and to ensure their reliability.
@@ -837,7 +837,7 @@ Consider:
 
 ---
 
-_When you assume you make an 'ass' out of 'u' and 'me'_. Everyone knows this saying, yet few of us heed it's warning. 
+_When you assume you make an 'ass' out of 'u' and 'me'_. Everyone knows this saying, yet few of us heed its warning. 
 
 The aim should be to leave your work in a state that others (including future you!), can pick it up and immediately find what they need, understanding the processes that have happened previously. Changes to files should be documented, and published versions should be clearly named and stored in their own folder.
 
@@ -1001,7 +1001,7 @@ The [Self-assessment tool](https://github.com/dfe-analytical-services/publicatio
 
 If you do not already have git downloaded, you can [download the latest version from their website](https://git-scm.com/downloads).
 
-For now, take a look at at the [resources for learning Git](../learning-development/learning-development.html#git) on the learning resources page.
+For now, take a look at at the [resources for learning git](../learning-development/learning-development.html#git) on the learning resources page.
 
 ---
 

--- a/RAP/rap-statistics.qmd
+++ b/RAP/rap-statistics.qmd
@@ -1,5 +1,6 @@
 ---
 title: "RAP for Statistics"
+
 ---
 
 ```{r include=FALSE}
@@ -71,7 +72,7 @@ The collection of, and routine checking of data as it is coming into the departm
 
 ---
 
-The diagram below highlights what RAP means for us, and the varying levels in which it can be applied. The expectation is that all publications will meet the department's baseline implementation of RAP in the self-assessment tool. It's worth acknowledging that some teams are already working around great and best practice levels, and that we appreciate every team's situation is unique, our guidance is designed to be applicable across all official statistcs publications by DfE.
+The diagram below highlights what RAP means for us, and the varying levels in which it can be applied in all types of analysis. You can click on each of the hexagons in the diagram to learn more about each of the RAP principles and how to use them in practice. The expectation is that all publications will meet the department's baseline implementation of RAP in the self-assessment tool. It's worth acknowledging that some teams are already working around great and best practice levels, and that we appreciate every team's situation is unique, our guidance is designed to be applicable across all official statistics publications by DfE.
 
 
 <html>
@@ -117,11 +118,7 @@ Some teams will already be looking at best practice, while others will still hav
 
 
 
-Most teams have already made progress with their production of tidy data files, and the release of the automated screener has now tied up that end point of the pipeline that we are all currently working towards. The standard pipeline for all teams will roughly resemble this:
-
-
-`r knitr::include_graphics("../images/RAP-Process-Overview.png")`
-
+Most teams have already made progress with their production of tidy data files, and the release of the automated screener has now tied up that end point of the pipeline that we are all currently working towards. 
 
 The key now is for us to build on the work so far and focus on how we improve the quality and efficiency of our production processes up to that point. To do this, we need to make a concerted effort to standardise how we store and access our data, before then automating what we can to reduce the burden of getting the numbers ready and see the benefits of RAP. The exact meaning of this will vary within teams.
 
@@ -129,6 +126,7 @@ The key now is for us to build on the work so far and focus on how we improve th
 
 ## How to get started
 
+Check your analysis against the Good, Great and Best practice standards under [RAP in practice](/RAP/rap-statistics.html#rap-in-practice).
 
 Measure your publication against the RAP levels using our [self assessment tool](https://rsconnect/rsc/publication-self-assessment/){target="_blank" rel="noopener noreferrer"}. This will give you a good starting point and initial points to work on to progress to the next level of RAP.
 
@@ -189,7 +187,7 @@ There are a few different options, depending on where you want your new area to 
 
 If your data is already in SQL, you can use this snippet of R code to move tables from one area (e.g. the iStore) to another (e.g. your team's modelling area) to ensure all data are stored in a database.
 
-```
+``` {r connection_example, eval=FALSE}
 library(odbc)
 library(dplyr)
 library(dbplyr)
@@ -261,7 +259,7 @@ This should take you to a new window which contains the raw data from the CSV fi
 
 You can now use this URL as you would use a file path in a `read.csv()` query. For example;
 
-```
+```{r devolved_lookup, eval=FALSE}
 devolved_area_lookup <- read.csv("https://raw.githubusercontent.com/dfe-analytical-services/dfe-published-data-qa/master/data/english_devolved_areas.csv")
 ```
 
@@ -325,7 +323,7 @@ Using the `%>%` pipe in R can be incredibly powerful, and make your code much ea
 A quick example of how powerful this is is below, where my_data is processed to create new columns, have column names renamed, have the column names tidied using the [janitor](https://garthtarr.github.io/meatR/janitor.html){target="_blank" rel="noopener noreferrer"} package, blank rows and columns removed, data filtered to only include specific geographic levels, and rows rearranged in order, all in a few lines of easy to follow code:
 
 
-```{r example, eval=FALSE}
+```{r example, eval=FALSE, style="background-color: #f7fdfa"}
 processed_regional_data <- my_data %>% 
   mutate(newPercentageColumn = (numberColumn / totalPopulationColumn) * 100) %>% 
   rename(newPercentageColumn = percentageRate,
@@ -478,7 +476,7 @@ Review your code and consider the following:
 
 For example, if you refer to the year of publication in your code a lot, consider replacing every instance with a named variable, which you only need to change once at the start of your code. In the example below, the year is set at the top of the code, and is used to define "prev_year", both of which are used further down the code to filter the data based on year.
 
-``` {r this_last_year, eval=FALSE}
+``` {r this_last_year, eval=FALSE, style="background-color: #f7fdfa"}
 
 this_year <- 2020
 prev_year <- this_year - 1
@@ -645,7 +643,7 @@ Peer reviewing code and not sure where to start? Improving code performance can 
 
 For example below, we are testing out case_when, if_else and ifelse.
 
-```
+``` {r microbenchmark, eval=FALSE}
 microbenchmark::microbenchmark( 
    case_when(1:1000 < 3 ~ "low", TRUE ~ "high"), 
    if_else(1:1000 < 3, "low", "high"),
@@ -655,7 +653,7 @@ microbenchmark::microbenchmark(
 
 Running the code outputs a table in the R console, giving profile stats for each expression. Here, it is clear that on average, if_else() is the fastest function for the job.
 
-```
+``` {r code_outputs, eval=FALSE}
 Unit: microseconds
                                          expr     min       lq     mean   median       uq      max neval
  case_when(1:1000 < 3 ~ "low", TRUE ~ "high") 167.901 206.2510 372.7321 300.2515 420.1005 4187.001   100
@@ -932,22 +930,22 @@ Take a look at the sections below for further guidance on improving your documen
 
 When writing code, whether that is SQL, R, or something else, make sure you're commenting as you go. Start off every file by outlining the date, author, purpose, and if applicable, the structure of the file, like this: 
 
-```
-----------------------------------------------------------------------------------------------
+```{r comments_example, eval=FALSE}
+----------------------------------------------------------------------------------------
 -- Script Name:		Section 251 Table A 2019 - s251_tA_2019.sql
 -- Description:		Extraction of data from IStore and production of underlying data file
 -- Author:		    Cam Race
 -- Creation Date:   15/11/2019
-----------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------
 
-----------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------
 --//  Process
 -- 1. Extract the data for each available year
 -- 2. Match in extra geographical information
 -- 3. Create aggregations - both categorical and geographical totals
 -- 4. Tidy up and output results
 -- 5. Metadata creation
-----------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------
 ```
 
 Commented lines should begin with -- (SQL) or # (R), followed by one space and your comment. Remember that **comments should explain the why, not the what.** 
@@ -959,8 +957,8 @@ In rmarkdown documents you can bookend comments by using `<!--` and `-->`.
 Use commented lines of - to break up your files into scannable chunks based upon the structure and subheadings, like the R example below:
 
 
-```
-# Importing the data -----------------------------------------------------------------------------------
+``` {r comments_example_2, eval=FALSE}
+# Importing the data -------------------------------------------------------------------
 
 ```
 
@@ -1013,7 +1011,7 @@ For now, take a look at at the [resources for learning git](../learning-developm
 
 **What does this mean?**
 
-This means having the final copies of code and documentation saved in a git-controlled Azure DevOps repo in the official-statistics-production area.
+This means having the final copies of code and documentation saved in a git-controlled Azure DevOps repo in the official-statistics-production area. Access to DevOps is restricted only to people in DfE with specific account permissions. This is different to GitHub, which makes code publicly available. 
 
 **Why do it?**
 
@@ -1167,7 +1165,7 @@ To clone code, they will need to do the following:
 
 3. After running those lines, type in the following with your repository URL in the "YOUR_URL_HERE" space. This will clone the online repository to your local area.
 
-``` {r git_team_steps, eval=FALSE}
+``` {r git_team_steps, eval=FALSE} 
 git clone YOUR_URL_HERE
 ```
 

--- a/RAP/rap-support.qmd
+++ b/RAP/rap-support.qmd
@@ -25,8 +25,8 @@ Learning resources and materials for [SQL](../learning-development/sql.html), [R
 
  *	In person workshops covering specific technical skills in practice
  *	3 hours long, with people working in small groups
- *	Recently circled the sites running an introduction to Git, and introduction to R and RAP.
- * Contact statistics.development@education.gov.uk to register interest in workshops happening at your site or to request new topics!
+ *	We currently offer two workshops: introduction to git and DevOps, and introduction to R and RAP. We can travel to your site to deliver these. 
+ * Contact [statistics.development@education.gov.uk](mailto:statistics.development@education.gov.uk) to register interest in workshops happening at your site or to request new topics!
 
 We’re also considering a dedicated G6 / G7 programme to build confidence and set expectations. This may include:
 
@@ -34,7 +34,7 @@ We’re also considering a dedicated G6 / G7 programme to build confidence and s
  * There will be take away materials that cover lines to take and where to get support.
  * All G6s and G7s are expected to do this, with repeats running to ensure everyone gets a chance to attend.
  
-Keep an eye out on teams for this programme being advertised and contact [statistics.development@education.gov.uk](mailto:statistics.development@education.gov.uk).
+Keep an eye out on Teams for this programme being advertised and contact [statistics.development@education.gov.uk](mailto:statistics.development@education.gov.uk) if you'd like to discuss it.
 
 ---
 
@@ -48,7 +48,7 @@ The Statistics Development Team invites teams to take part in our partnership pr
 * Streamlining data production processes to free up time for secondary analysis
 * Improving the presentation and consistency of statistical products for users
 
-The partnership programme is a great opportunity to work with the Statistics Development Team, using protected time to work on things that are otherwise usually deprioritised. We understand the pressures of BAU work mean that development time is often hard fit in, but this programme offers designated support and clear project planning from our team so that these improvements can be achieved. Putting in the work at these early stages will save more time and resource in the long run, and we are keen to support as many teams as possible to free up time in the future for even more interesting analysis.
+The partnership programme is a great opportunity to work with the Statistics Development Team, using protected time to work on things that are otherwise usually deprioritised. We understand the pressures of BAU work mean that development time is often hard to fit in, but this programme offers designated support and clear project planning from our team so that these improvements can be achieved. Putting in the work at these early stages will save more time and resource in the long run, and we are keen to support as many teams as possible to free up time in the future for even more interesting analysis.
 
 **The Ask**
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -111,6 +111,7 @@ format:
       light: slate
       dark: united
     code-copy: true
+    highlight-style: printing
     code-overflow: wrap
     toc: true
 

--- a/index.qmd
+++ b/index.qmd
@@ -74,6 +74,9 @@ We hope it can prove a useful community driven resource for everyone from the mo
 
 ## Reproducible Analytical Pipelines (RAP)
 
+[RAP in statistics](RAP/rap-statistics.html)
+- Detailed RAP guidance for statistics publications
+
 [RAP expectations](RAP/rap-expectations.html)
 - Guidance for all analysts on expectations of RAP
 
@@ -83,10 +86,7 @@ We hope it can prove a useful community driven resource for everyone from the mo
 [RAP FAQs](RAP/rap-faq.html)
 - Frequently asked questions about RAP
 
-[RAP in statistics](RAP/rap-statistics.html)
-- Detailed RAP guidance for statistics publications
-
-## ADA and databricks
+## ADA and Databricks
 
 [Something]()
 - ? TBC


### PR DESCRIPTION
## Overview of changes
I added some extra details and fixed some typos (sorry) on all 4 pages. 

On the **RAP for Statistics page** I have quite a few suggested changes but I didn't want to make these without running them by someone first. They are:
- I think this page should come first in the list of RAP pages as it's a good overview
- I don't know whether it's maybe worth adding a table of contents linking to each of the RAP principles, but this might be too long/unwieldy given how many of them there are. Might be useful for people looking for a specific section though. 
- The diagram under "Where do we need to focus" is too small and difficult to read, and you can't expand it/zoom in. The same is true for the diagrams under "Version controlled final code scripts". 
- "How to get started" only refers to publications, do we need more generic info for non-publication related RAP?
- Some of the code snippets on the page show up ok but are difficult to differentiate from the other text despite the change in font, and other code snippets (like the ones under the "Tidying and processing data in R", "Recyclable code for future use", and "Build capability with in the team" sections) are pretty much impossible to read because of the font colours against the dark background. Could we maybe put code snippets inside boxes with a different colour background or something? 
- Under "Version controlled final code scripts", do we need to more clearly differentiate between the use case for DevOps (private) and GitHub (open source)? It's implied but not sure how clear it'd be to people that are new to using both. 

I maybe should have added these as comments on the actual bits of Markdown text. I can go back and do that if it's better 😄 

Also I asked to merge this to main because there's no development branch that I can see - sorry!
