### PR TITLE
Add sql style guide

### DIFF
--- a/learning-development/sql.qmd
+++ b/learning-development/sql.qmd
@@ -26,7 +26,7 @@ Download SSMS from the DfE software center, talk to your team about getting acce
 
 There are usually a couple of different versions available for software on the software center, we'd recommend you always go for the latest (newest) version possible.
 
-<!-- gif getting this from the software center -->
+If you can't find the option in the software centre, then you may need to raise a [service desk request to make SQL server management studio visible](https://dfe.service-now.com/serviceportal?id=sc_cat_item&sys_id=55d3f68edb7b66005ca2fddabf96197e) in your software centre.
 
 ---
 

--- a/learning-development/sql.qmd
+++ b/learning-development/sql.qmd
@@ -51,6 +51,8 @@ Here are some tips to follow best practice in your SQL code, making it easier to
 * Try to only comment on things that aren't obvious about the query (e.g. why hardcoded filters are used, how to update them)
 * Where possible, use [Common Table Expressions (CTEs)](https://www.essentialsql.com/introduction-common-table-expressions-ctes/){target="_blank" rel="noopener noreferrer"} early and often, and name them descriptively (e.g. "pupil_age_table" rather than "p")
 
+[GitLab](https://about.gitlab.com/) have produced a full [SQL style guide](https://about.gitlab.com/handbook/business-technology/data-team/platform/sql-style-guide/), which we recommend following where possible.
+
 ---
 
 ## How to work with SQL


### PR DESCRIPTION
## Overview of changes

Add a link to GitLab's SQL style guide, as well as update the accessing SSMS section to have a service desk link.

## Why are these changes being made?

Style guide looks useful, and we don't currently link to one for SQL. It aligns with the notes we already have on the page but gives extra detail as well.

SSMS now requires a service desk request for it to appear in your software centre to download, noticed our notes on it were out of date so updated to add the link for the request.

## Detailed description of changes

Not applicable.

## Issue ticket number/s and link

No related issues.

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
