### PR TITLE
Update cheatsheet links

### DIFF
--- a/learning-development/r.qmd
+++ b/learning-development/r.qmd
@@ -159,16 +159,16 @@ This is surprisingly neat to do. Let's say you wanted to roll back to version 1.
 
 
 - If you want a useful guide for R syntax or functions, then look no further than the [R cheat sheets](https://rstudio.com/resources/cheatsheets/){target="_blank" rel="noopener noreferrer"}, these can be an invaluable point of reference. Below we've included a few particularly relevant ones:
-    + Introduction to the [RStudio environment](https://github.com/rstudio/cheatsheets/raw/master/rstudio-ide.pdf){target="_blank" rel="noopener noreferrer"}
-    + [Base R](http://github.com/rstudio/cheatsheets/raw/master/base-r.pdf){target="_blank" rel="noopener noreferrer"}
-    + [Importing data into R](https://github.com/rstudio/cheatsheets/raw/master/data-import.pdf){target="_blank" rel="noopener noreferrer"}
-    + [dplyr](https://github.com/rstudio/cheatsheets/raw/master/data-transformation.pdf){target="_blank" rel="noopener noreferrer"} for data manipulation
-    + [stringr](https://github.com/rstudio/cheatsheets/raw/master/strings.pdf){target="_blank" rel="noopener noreferrer"} for string manipulation
-    + [Regex](https://github.com/rstudio/cheatsheets/raw/master/regex.pdf){target="_blank" rel="noopener noreferrer"}
-    + [RMarkdown](https://rstudio.com/wp-content/uploads/2015/02/rmarkdown-cheatsheet.pdf){target="_blank" rel="noopener noreferrer"}
-    + [RShiny](https://github.com/rstudio/cheatsheets/raw/master/shiny.pdf){target="_blank" rel="noopener noreferrer"}
-    + [ggplot2](https://rstudio.com/wp-content/uploads/2015/03/ggplot2-cheatsheet.pdf){target="_blank" rel="noopener noreferrer"} for data visualisations
-    + [purrr](https://github.com/rstudio/cheatsheets/raw/master/purrr.pdf){target="_blank" rel="noopener noreferrer"} for applying functions
+    + Introduction to the [RStudio environment](https://rstudio.github.io/cheatsheets/html/rstudio-ide.html){target="_blank" rel="noopener noreferrer"}
+    + [Base R](https://rstudio.github.io/cheatsheets/base-r.pdf){target="_blank" rel="noopener noreferrer"}
+    + [dplyr](https://rstudio.github.io/cheatsheets/html/data-transformation.html){target="_blank" rel="noopener noreferrer"} for data manipulation
+    + [Data import with the tidyverse](https://rstudio.github.io/cheatsheets/html/data-import.html){target="_blank" rel="noopener noreferrer"} 
+    + [stringr](https://rstudio.github.io/cheatsheets/html/strings.html){target="_blank" rel="noopener noreferrer"} for string manipulation
+    + [Regex](https://rstudio.github.io/cheatsheets/regex.pdf){target="_blank" rel="noopener noreferrer"}
+    + [RMarkdown](https://rstudio.github.io/cheatsheets/html/rmarkdown.html){target="_blank" rel="noopener noreferrer"}
+    + [RShiny](https://rstudio.github.io/cheatsheets/html/shiny.html){target="_blank" rel="noopener noreferrer"}
+    + [ggplot2](https://rstudio.github.io/cheatsheets/html/data-visualization.html){target="_blank" rel="noopener noreferrer"} for data visualisations
+    + [purrr](https://rstudio.github.io/cheatsheets/html/purrr.html){target="_blank" rel="noopener noreferrer"} for applying functions
 
 ---
 


### PR DESCRIPTION
## Overview of changes

We noticed in the workshop these are broken. I think this is because RStudio is now POSIT and they've moved where they store the cheatsheets about a bit and made some as full html pages.

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [ ] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
