### PR TITLE
Add git commit message guidance

### DIFF
--- a/learning-development/git.qmd
+++ b/learning-development/git.qmd
@@ -95,13 +95,14 @@ However, you can still run the full suite of git commands by simply typing them 
 
 ## Tips for using Git
 
----
 
 ### Commits
 
 ---
 
-The best advice is to just commit regularly, like you would if you were saving a word document. Especially when you have working code or have just added something new. Each commit is a saved point in time that you can easily roll back to if needed. If you want to know more about how to do this, see the [reverting a commit](#reverting-a-commit) section below. 
+The best advice is to just commit regularly, like you would if you were saving a word document.
+
+Each commit is a saved point in time that you can easily roll back to if needed. If you want to know more about how to do this, see the [reverting a commit](#reverting-a-commit) section below. 
 
 ---
 
@@ -111,12 +112,14 @@ The best advice is to just commit regularly, like you would if you were saving a
 
 The best advice for commit messages is to keep them clear, simple and brief. 
 
-It is recommended to use the imperative tone e.g. 'Add fix for joining pupil table' rather than 'Added' or 'Adding'. Other general recommendations include:
+It is recommended to use the imperative tone e.g. `Add fix for joining pupil table` rather than `Added ...` or `Adding ...`. Other general recommendations include:
 
 - Keep it short (max 150 characters if possible) - committing regularly can help with this
-- Explain what the change is and why the change was needed. You generally don’t need to go into the detail of how the change was made as this should be visible from the code (e.g., 'Add x to prevent y' or 'Add x so that y can z')
-- Don’t assume the reviewer understands what the original problem was (would someone else looking at it, or even yourself in a week’s time know what the commit was doing)
-- Capitalise the first letter and don’t end with punctuation, it's unnecessary
+- Explain what the change is and why the change was needed. You generally don’t need to go into the detail of how the change was made as this should be visible from the code
+   - e.g., `Add x to prevent y` or `Add x so that y can z`
+- Don’t assume the reviewer understands what the original problem was
+   - would someone else looking at it, or even yourself in a week’s time know what the commit was doing?
+- Capitalise the first letter and don’t end with punctuation, it is unnecessary
 
 If you're struggling to know what to write, remember the reader (including future you) is unlikely to have much context when looking through the version log to find the right point in time, try considering the following:
 

--- a/learning-development/git.qmd
+++ b/learning-development/git.qmd
@@ -109,7 +109,14 @@ The best advice is to just commit regularly, like you would if you were saving a
 
 ---
 
-The best advice for commit messages is to keep them clear, simple and brief. It is also recommended to use the imperative tone e.g. 'Add fix for joining pupil table' rather than 'Added' or 'Adding'. 
+The best advice for commit messages is to keep them clear, simple and brief. 
+
+It is recommended to use the imperative tone e.g. 'Add fix for joining pupil table' rather than 'Added' or 'Adding'. Other general recommendations include:
+
+- Keep it short (max 150 characters if possible) - committing regularly can help with this
+- Explain what the change is and why the change was needed. You generally don’t need to go into the detail of how the change was made as this should be visible from the code (e.g., 'Add x to prevent y' or 'Add x so that y can z')
+- Don’t assume the reviewer understands what the original problem was (would someone else looking at it, or even yourself in a week’s time know what the commit was doing)
+- Capitalise the first letter and don’t end with punctuation, it's unnecessary
 
 If you're struggling to know what to write, remember the reader (including future you) is unlikely to have much context when looking through the version log to find the right point in time, try considering the following:
 
@@ -118,7 +125,7 @@ If you're struggling to know what to write, remember the reader (including futur
 - Why was the change needed?
 - What are the changes in reference to?
 
-Never leave a commit message blank.
+Never leave a commit message blank. The information you include could really pay off later when you need to remember what you worked on, or share it with other people.
 
 There are specific conventions outlined in [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), that are worth familiarising yourself as you begin to use Git more. Following these conventions will help you write messages that are consistent with [over 100 million other Git users](https://github.blog/2023-01-25-100-million-developers-and-counting/) around the world.
 

--- a/learning-development/git.qmd
+++ b/learning-development/git.qmd
@@ -95,7 +95,54 @@ However, you can still run the full suite of git commands by simply typing them 
 
 ## Tips for using Git
 
+---
 
+### Commits
+
+---
+
+The best advice is to just commit regularly, like you would if you were saving a word document. Especially when you have working code or have just added something new. Each commit is a saved point in time that you can easily roll back to if needed. If you want to know more about how to do this, see the [reverting a commit](#reverting-a-commit) section below. 
+
+---
+
+#### Commit messages
+
+---
+
+The best advice for commit messages is to keep them clear, simple and brief. It is also recommended to use the imperative tone e.g. 'Add fix for joining pupil table' rather than 'Added' or 'Adding'. 
+
+If you're struggling to know what to write, remember the reader (including future you) is unlikely to have much context when looking through the version log to find the right point in time, try considering the following:
+
+- Why have I made these changes?
+- What effect have my changes made?
+- Why was the change needed?
+- What are the changes in reference to?
+
+Never leave a commit message blank.
+
+There are specific conventions outlined in [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), that are worth familiarising yourself as you begin to use Git more. Following these conventions will help you write messages that are consistent with [over 100 million other Git users](https://github.blog/2023-01-25-100-million-developers-and-counting/) around the world.
+
+---
+
+#### In RStudio
+
+---
+
+Once you are happy with changes and want them to be in the latest version of your branch for all of your team to see, you can push "commits" up.
+
+- When you make a change to a file, this will pop up in the "Git" window of your R console. Select the files you want to commit by ticking the "staged" box next to them.
+
+![](../images/git_stage.png)
+
+- This will bring up a new window. Add a comment describing your additions/changes, and click commit. You will see all the staged files disappear. Then click “Push” to push the committed files up to the online repository for all to use.
+
+![](../images/git_push.png)
+
+- When another member of your team makes a commit and you want to pull this into your local area to check and work off the latest version, click on the blue "pull" button.
+
+![](../images/pull_git.png)
+
+---
 
 ### Branches
 
@@ -118,28 +165,6 @@ When you create a git project, it will automatically create a "main" (sometimes 
 - When working on your project, make sure that you are in the right branch. You can check this by navigating to the "Git" tab in RStudio as demonstrated below.
 
 ![](../images/select_branch.png)
-
----
-
-### Commits
-
----
-
-Once you are happy with changes and want them to be in the latest version of your branch for all of your team to see, you can push "commits" up.
-
-- When you make a change to a file, this will pop up in the "Git" window of your R console. Select the files you want to commit by ticking the "staged" box next to them.
-
-![](../images/git_stage.png)
-
-- This will bring up a new window. Add a comment describing your additions/changes, and click commit. You will see all the staged files disappear. Then click “Push” to push the committed files up to the online repository for all to use.
-
-![](../images/git_push.png)
-
-- When another member of your team makes a commit and you want to pull this into your local area to check and work off the latest version, click on the blue "pull" button.
-
-![](../images/pull_git.png)
-
-Committing regularly is strongly recommended as each commit is a saved point in time that you can easily roll back to if needed. If you want to know more about how to do this, see the [reverting a commit](#reverting-a-commit) section below. 
 
 ---
 


### PR DESCRIPTION
## Overview of changes

Add guidance on how to write good commit messages when using Git.

## Why are these changes being made?

It's a question we regularly get from new starters, plus I wanted a place to stash a link to the Git commit convention site too for future reference.

## Detailed description of changes

1. Have moved the commits section above the branches section under 'Tips for using Git' as it felt like a more logical starting place (though up for debate!)
2. Added generic advice on committing regularly (another frequent question we get)
3. Moved the existing commit guidance into a specific 'In RStudio section'
4. Added details on how to write good commit messages and a link to the commit conventions site

Screenshot of a local build showing the formatting of the new guidance:
![image](https://github.com/dfe-analytical-services/analysts-guide/assets/52536248/4317e6e1-dacc-4cf0-9384-703dd27f2413)

## Issue ticket number/s and link

N/A - though there is a [Trello card on our SDT board that Tess](https://trello.com/c/uy8MALuw/860-add-guidance-on-good-commit-message-practices-to-our-git-page-on-the-analysts-guide?search_id=467a7de0-11a9-46ce-8d60-7b8635933820) had added some notes to.

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
