### PR TITLE
updating dark theme because the other one broke

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -114,7 +114,7 @@ website:
 format:
   html:
     theme:
-      light: slate
+      light: cyborg
       dark: united
     code-copy: true
     highlight-style: printing


### PR DESCRIPTION
Temporarily changed dark theme from [https://bootswatch.com/slate/](https://bootswatch.com/slate/) to [https://bootswatch.com/cyborg/](https://bootswatch.com/cyborg/) until we can get a fix in for the old dark theme
