### PR TITLE
fixing broken image links

### DIFF
--- a/ADA/git_databricks.qmd
+++ b/ADA/git_databricks.qmd
@@ -80,15 +80,15 @@ Access tokens are long strings of numbers and letters that act like a password b
 
 In this case, we will generate an access token in DevOps and give it to Databricks. To generate your Azure DevOps access token, go to DevOps and click the user settings icon to the left of your initials in the top right of your screen - it looks like a person with a cog next to them:
 
-![](../images/devops-user-settings.PNG)
+![](../images/devops-user-settings.png)
 
 In the user settings menu, click Personal Access Tokens. On the screen that appears, click the blue "New Token" button in the top right:
 
-![](../images/devops-new-token.PNG)
+![](../images/devops-new-token.png)
 
 The following window should appear: 
 
-![](../images/devops-create-token.PNG)
+![](../images/devops-create-token.png)
 
 - Give the token a sensible name so that you can identify it in your list of tokens.
 - The organisation field should be pre-populated for you, this can be left alone. 
@@ -108,11 +108,11 @@ A "Success!" window will open containing your new access token. **You must copy 
 
 Now that you have your access token, you should go straight to Databricks. In the top right corner of the Databricks window, click your username and then "User Settings":
 
-![](../images/databricks-user-settings.PNG)
+![](../images/databricks-user-settings.png)
 
 You should then select "Linked Accounts" from the User menu on the left. The following page will open:
 
-![](../images/databricks-linked-accounts.PNG)
+![](../images/databricks-linked-accounts.png)
 
 - We recommend immediately pasting your copied access token into the "Token" field at the bottom of the page to avoid losing it.
 - Git provider should be set as "Azure DevOps Services (Personal Access Token)" 
@@ -132,11 +132,11 @@ Just like any other way that you've worked with git before, the first step is go
 
 In the blue menu on the left, click Workspace, and then in the Workspace menu that appears, click Repos. The menus should look like this:
 
-![](../images/databricks-workspace-menu.PNG)
+![](../images/databricks-workspace-menu.png)
 
 On the Repos screen, click the grey "Add repo" button in the top right corner. The "Add Repo" window will appear:
 
-![](../images/databricks-add-repo.PNG)
+![](../images/databricks-add-repo.png)
 
 - You will first need to go to Azure DevOps and copy the link to clone the repo as you usually would
 - Paste this link into the "Git repository URL" field
@@ -145,7 +145,7 @@ On the Repos screen, click the grey "Add repo" button in the top right corner. T
 
 You can then click "Create Repo". When the repo is created, you will be able to see it under your name in the Repos menu:
 
-![](../images/databricks-view-repo.PNG)
+![](../images/databricks-view-repo.png)
 
 #### Sparse checkout and Cone Patterns
 
@@ -175,7 +175,7 @@ Please note: You cannot currently disable sparse checkout mode once it is enable
 To be able to add your notebooks to a repo, you need to make sure that you save them in the correct place. 
 In Databricks, you have your Workspace. Inside your Workspace is your "local" Users folder, and your repos. In the image below, the User folder is highlighted blue:
 
-![](../images/databricks-folders.PNG)
+![](../images/databricks-folders.png)
 
 You can think of your User folder as being a bit like "My Documents" on your laptop. When you save things there, only you can see and access them. Git cannot "see" things inside your User folder. However, git **can** see things inside your Repos folder. This means that when you save something in your Repos folder, it can be committed and pushed to git. It is therefore good practice to always save notebooks in your Repos folder instead of in your User folder. 
 
@@ -193,15 +193,15 @@ You can access the menu to pull, commit and push from several places within Data
 
 At the top of any notebook that's saved in a repo, you'll see a little grey branch icon with the name of a repo next to it. In the case of this notebook, it's on the main branch:
 
-![](../images/databricks-main-repo-notebook.PNG)
+![](../images/databricks-main-repo-notebook.png)
 
 You can also access the git menu by clicking the branch name next to the repo name within the Repos folder:
 
-![](../images/databricks-main-repo-menu.PNG)
+![](../images/databricks-main-repo-menu.png)
 
 If you click the branch name, it'll open the git interface within Databricks:
 
-![](../images/databricks-git-interface.PNG)
+![](../images/databricks-git-interface.png)
 
 From here, you can perform git pull by clicking the pull icon in the top right. There is a dropdown menu in the top left corner that allows you to change the branch or create a new branch if required. 
 
@@ -214,7 +214,7 @@ From here, you can perform git pull by clicking the pull icon in the top right. 
 
 When you have made changes to a notebook, it will appear in the Changes section of the git interface. You can also see the actual changes that have been made in the right hand box to make sure that you're committing the correct file: 
 
-![](../images/databricks-git-commit.PNG)
+![](../images/databricks-git-commit.png)
 
 In Databricks, you commit and push as one action, rather than as two separate ones. Enter your commit message into the "Commit message" box (you can ignore the Description box) and click the "Commit & Push" button. 
 
@@ -224,7 +224,7 @@ In Databricks, you commit and push as one action, rather than as two separate on
 
 You can access additional git features such as merge, rebase and reset directly within the Databricks interface by clicking the 3 dots in the menu as shown in the image below:
 
-![](../images/reset-local-branch.PNG)
+![](../images/reset-local-branch.png)
 
 When merging, you are also able to resolve merge conflicts inside Databricks itself. 
 


### PR DESCRIPTION
Images on [https://dfe-analytical-services.github.io/analysts-guide/ADA/git_databricks.html](https://dfe-analytical-services.github.io/analysts-guide/ADA/git_databricks.html) were broken as all of the .png file endings were in caps. They should all be working now! 