### PR TITLE
Added establishment types reference data

### DIFF
--- a/statistics-production/ud.qmd
+++ b/statistics-production/ud.qmd
@@ -1067,7 +1067,7 @@ A standardised set of establishment type fields has been developed, largely base
 
 :::
 
-If needed, these items can also be reporting in the standard **breakdown** field, using a **breakdown_topic** of Establishment type group.
+If needed, these items can also be reported in the standard **breakdown** field, using a **breakdown_topic** of Establishment type group.
 
 
 ---
@@ -1094,7 +1094,7 @@ The **establishment_governance** field provides an opportunity to list the gover
 
 :::
 
-If needed, these items can also be reporting in the standard **breakdown** field, using a **breakdown_topic** of Establishment governance.
+If needed, these items can also be reported in the standard **breakdown** field, using a **breakdown_topic** of Establishment governance.
 
 ---
 
@@ -1122,8 +1122,6 @@ Education phase should be listed under he column name **education_phase** where 
 | Secondary | SS |
 | Special | SP |
 | Total | |
-
-If needed, these items can also be reporting in the standard **breakdown** field, using a **breakdown_topic** of Education phase.
 
 :::
 

--- a/statistics-production/ud.qmd
+++ b/statistics-production/ud.qmd
@@ -1011,14 +1011,21 @@ A standardised set of establishment type fields has been developed, largely base
 
 ---
 
-| col_name | Breakdown topic entry | Filter item |
-| -------- | --------------------- | ----------- |
-| establishment_type_group | Establishment type group | Academy |
-| establishment_type_group | Establishment type group | Total |
-| establishment_type_group | Establishment type group | All state funded |
-| establishment_type_group | Establishment type group | Independent |
-| establishment_type_group | Establishment type group | Local authority maintained |
-| establishment_type_group | Establishment type group | Non-maintained |
+::: {.table-responsive}
+
+| establishment_type_group |
+| ----------- |
+| Academy |
+| All state funded |
+| Independent |
+| Local authority maintained |
+| Non-maintained |
+| Total |
+
+:::
+
+If needed, these items can also be reporting in the standard **breakdown** field, using a **breakdown_topic** of Establishment type group.
+
 
 ---
 
@@ -1028,16 +1035,23 @@ A standardised set of establishment type fields has been developed, largely base
 
 The **establishment_governance** field provides an opportunity to list the governance of an establishment, e.g. Academy, Non-maintained, Independent etc. It can be assigned the **establishment_type_group** as a filter grouping column.
 
-| col_name | Breakdown topic entry | Filter item |
-| -------- | --------------------- | ----------- |
-| establishment_governance | Establishment governance | Community |
-| establishment_governance | Establishment governance | Voluntary aided |
-| establishment_governance | Establishment governance | Voluntary controlled |
-| establishment_governance | Establishment governance | Foundation |
-| establishment_governance | Establishment governance | Independent |
-| establishment_governance | Establishment governance | Non-maintained |
-| establishment_governance | Establishment governance | City technology college |
-| establishment_governance | Establishment governance | Academy |
+::: {.table-responsive}
+
+| establishment_governance |
+| ----------- |
+| Academy |
+| City technology college |
+| Community |
+| Foundation |
+| Independent |
+| Non-maintained |
+| Voluntary aided |
+| Voluntary controlled |
+| Total |
+
+:::
+
+If needed, these items can also be reporting in the standard **breakdown** field, using a **breakdown_topic** of Establishment governance.
 
 ---
 
@@ -1047,22 +1061,28 @@ The **establishment_governance** field provides an opportunity to list the gover
 
 Education phase should be listed under he column name **education_phase** where given as a standalone filter or Education phase if included in the **breakdown_topic** / **breakdown** combination. When included as an individual filter, it can be attributed **establishment_type_group** as the filter grouping column where available.
 
-| col_name | Breakdown topic entry | Filter item | School census code |
-| -------- | --------------------- | ----------- | ------------------ |
-| education_phase | Education phase | All-through | AT |
-| education_phase | Education phase | Alternative provision | PR |
-| education_phase | Education phase | Early years settings | |
-| education_phase | Education phase | Independent school | |
-| education_phase | Education phase | Middle (deemed primary) | MP |
-| education_phase | Education phase | Middle (deemed secondary) | MS |
-| education_phase | Education phase | No establishment | |
-| education_phase | Education phase | Nursery | NS |
-| education_phase | Education phase | Primary | PS |
-| education_phase | Education phase | Secondary | SS |
-| education_phase | Education phase | Special | SP |
-| education_phase | Education phase | Further education | |
-| education_phase | Education phase | Higher education | |
-| education_phase | Education phase | Total | |
+::: {.table-responsive}
+
+| education_phase | School census code |
+| ----------- | ------------------ |
+| All-through | AT |
+| Alternative provision | PR |
+| Early years settings | |
+| Further education | |
+| Higher education | |
+| Independent school | |
+| Middle (deemed primary) | MP |
+| Middle (deemed secondary) | MS |
+| No establishment | |
+| Nursery | NS |
+| Primary | PS |
+| Secondary | SS |
+| Special | SP |
+| Total | |
+
+If needed, these items can also be reporting in the standard **breakdown** field, using a **breakdown_topic** of Education phase.
+
+:::
 
 ---
 

--- a/statistics-production/ud.qmd
+++ b/statistics-production/ud.qmd
@@ -856,7 +856,7 @@ Individual needs can be provided using **sen_primary_need** and **sen_secondary_
 
 The options for **sen_secondary_need** are the same as for **sen_primary_need**, except for **No primary need** is replaced by **No secondary need**.
 
-If using **breakdown_topic** and **breakdown** insead of individual columns, then the appropriate entries for **breakdown_topic** are SEN status, SEN provision, SEN primary need and SEN secondary need.
+If using [**breakdown_topic** and **breakdown**](#introduction-to-filters) instead of individual columns, then the appropriate entries for **breakdown_topic** are SEN status, SEN provision, SEN primary need and SEN secondary need.
 
 ---
 
@@ -882,7 +882,7 @@ certificate).
 
 When presented in a filter, this should take the column header **sex** and 
 standard entries **Male**, **Female** and **Unknown**. This can also be included as 
-part of the standard **breakdown_topic** / **breakdown** filters, with the relevant 
+part of the standard [**breakdown_topic** / **breakdown** filters](#introduction-to-filters), with the relevant 
 entry under **breakdown_topic** being **Sex** and as above, the entries under
 **breakdown** being **Male**, **Female** and **Unknown**.
 
@@ -1067,7 +1067,7 @@ A standardised set of establishment type fields has been developed, largely base
 
 :::
 
-If needed, these items can also be reported in the standard **breakdown** field, using a **breakdown_topic** of Establishment type group.
+If needed, these items can also be reported in the standard [**breakdown** field](#introduction-to-filters), using a **breakdown_topic** of Establishment type group.
 
 
 ---
@@ -1094,7 +1094,7 @@ The **establishment_governance** field provides an opportunity to list the gover
 
 :::
 
-If needed, these items can also be reported in the standard **breakdown** field, using a **breakdown_topic** of Establishment governance.
+If needed, these items can also be reported in the standard [**breakdown** field](#introduction-to-filters), using a **breakdown_topic** of Establishment governance.
 
 ---
 
@@ -1102,7 +1102,7 @@ If needed, these items can also be reported in the standard **breakdown** field,
 
 ---
 
-Education phase should be listed under he column name **education_phase** where given as a standalone filter or Education phase if included in the **breakdown_topic** / **breakdown** combination. When included as an individual filter, it can be attributed **establishment_type_group** as the filter grouping column where available.
+Education phase should be listed under he column name **education_phase** where given as a standalone filter or Education phase if included in the [**breakdown_topic** / **breakdown** combination](#introduction-to-filters). When included as an individual filter, it can be attributed **establishment_type_group** as the filter grouping column where available.
 
 ::: {.table-responsive}
 

--- a/statistics-production/ud.qmd
+++ b/statistics-production/ud.qmd
@@ -1001,6 +1001,13 @@ Where there is a reasonable need to publish or report statistics for a full aggr
 
 ---
 
+## School characteristics
+
+
+
+
+---
+
 # Filters
 
 ---

--- a/statistics-production/ud.qmd
+++ b/statistics-production/ud.qmd
@@ -1102,7 +1102,7 @@ If needed, these items can also be reported in the standard [**breakdown** field
 
 ---
 
-Education phase should be listed under he column name **education_phase** where given as a standalone filter or Education phase if included in the [**breakdown_topic** / **breakdown** combination](#introduction-to-filters). When included as an individual filter, it can be attributed **establishment_type_group** as the filter grouping column where available.
+Education phase should be listed under the column name **education_phase** where given as a standalone filter or Education phase if included in the [**breakdown_topic** / **breakdown** combination](#introduction-to-filters). When included as an individual filter, it can be attributed **establishment_type_group** as the filter grouping column where available.
 
 ::: {.table-responsive}
 

--- a/statistics-production/ud.qmd
+++ b/statistics-production/ud.qmd
@@ -1001,10 +1001,57 @@ Where there is a reasonable need to publish or report statistics for a full aggr
 
 ---
 
-## School characteristics
+## Esablishment characteristics
+
+A standardised set of establishment type fields has been developed, largely based on the data reported by the School and Pupils Statistics publication. Reference files for the standardised fields are available in the data screener GitHub repository, with the standards summarised below.
+
+### Esablishment type group
+
+| col_name | Breakdown topic entry | Filter item |
+| -------- | --------------------- | ----------- |
+| establishment_type_group | Establishment type group | Academy |
+| establishment_type_group | Establishment type group | Total |
+| establishment_type_group | Establishment type group | All state funded |
+| establishment_type_group | Establishment type group | Independent |
+| establishment_type_group | Establishment type group | LA maintained |
+| establishment_type_group | Establishment type group | Non-maintained |
+
+### Establishment governance
+
+The **establishment_governance** field provides an opportunity to list the governance of an establishment, e.g. Academy, Non-maintained, Independent etc. It can be assigned the **establishment_type_group** as a filter grouping column.
+
+| col_name | Breakdown topic entry | Filter item |
+| -------- | --------------------- | ----------- |
+| establishment_governance | Establishment governance | Community |
+| establishment_governance | Establishment governance | Voluntary aided |
+| establishment_governance | Establishment governance | Voluntary controlled |
+| establishment_governance | Establishment governance | Foundation |
+| establishment_governance | Establishment governance | Independent |
+| establishment_governance | Establishment governance | Non-maintained |
+| establishment_governance | Establishment governance | City technology college |
+| establishment_governance | Establishment governance | Academy |
 
 
+### Education phase
 
+Education phase should be listed under he column name **education_phase** where given as a standalone filter or Education phase if included in the **breakdown_topic** / **breakdown** combination. When included as an individual filter, it can be attributed **establishment_type_group** as the filter grouping column where available.
+
+| col_name | Breakdown topic entry | Filter item | School census code |
+| -------- | --------------------- | ----------- | ------------------ |
+| education_phase | Education phase | All-through | AT |
+| education_phase | Education phase | Alternative provision | PR |
+| education_phase | Education phase | Early years settings | |
+| education_phase | Education phase | Independent school | |
+| education_phase | Education phase | Middle (deemed primary) | MP |
+| education_phase | Education phase | Middle (deemed secondary) | MS |
+| education_phase | Education phase | No establishment | |
+| education_phase | Education phase | Nursery | NS |
+| education_phase | Education phase | Primary | PS |
+| education_phase | Education phase | Secondary | SS |
+| education_phase | Education phase | Special | SP |
+| education_phase | Education phase | Further education | |
+| education_phase | Education phase | Higher education | |
+| education_phase | Education phase | Total | |
 
 ---
 

--- a/statistics-production/ud.qmd
+++ b/statistics-production/ud.qmd
@@ -1005,7 +1005,7 @@ Where there is a reasonable need to publish or report statistics for a full aggr
 
 A standardised set of establishment type fields has been developed, largely based on the data reported by the School and Pupils Statistics publication. Reference files for the standardised fields are available in the data screener GitHub repository, with the standards summarised below.
 
-### Esablishment type group
+### Establishment type group
 
 | col_name | Breakdown topic entry | Filter item |
 | -------- | --------------------- | ----------- |

--- a/statistics-production/ud.qmd
+++ b/statistics-production/ud.qmd
@@ -1001,11 +1001,15 @@ Where there is a reasonable need to publish or report statistics for a full aggr
 
 ---
 
-## Esablishment characteristics
+## Establishment characteristics
 
 A standardised set of establishment type fields has been developed, largely based on the data reported by the School and Pupils Statistics publication. Reference files for the standardised fields are available in the data screener GitHub repository, with the standards summarised below.
 
+---
+
 ### Establishment type group
+
+---
 
 | col_name | Breakdown topic entry | Filter item |
 | -------- | --------------------- | ----------- |
@@ -1013,10 +1017,14 @@ A standardised set of establishment type fields has been developed, largely base
 | establishment_type_group | Establishment type group | Total |
 | establishment_type_group | Establishment type group | All state funded |
 | establishment_type_group | Establishment type group | Independent |
-| establishment_type_group | Establishment type group | LA maintained |
+| establishment_type_group | Establishment type group | Local authority maintained |
 | establishment_type_group | Establishment type group | Non-maintained |
 
+---
+
 ### Establishment governance
+
+---
 
 The **establishment_governance** field provides an opportunity to list the governance of an establishment, e.g. Academy, Non-maintained, Independent etc. It can be assigned the **establishment_type_group** as a filter grouping column.
 
@@ -1031,8 +1039,11 @@ The **establishment_governance** field provides an opportunity to list the gover
 | establishment_governance | Establishment governance | City technology college |
 | establishment_governance | Establishment governance | Academy |
 
+---
 
 ### Education phase
+
+---
 
 Education phase should be listed under he column name **education_phase** where given as a standalone filter or Education phase if included in the **breakdown_topic** / **breakdown** combination. When included as an individual filter, it can be attributed **establishment_type_group** as the filter grouping column where available.
 


### PR DESCRIPTION
## Overview of changes

Similar to the SEN data guidance update, this presents the first iteration of standardisation of the school type fields as reviewed by the data harmonisation champions.

## Why are these changes being made?

These are part of the ongoing effort to establish standardised data guidance for publication teams to follow.

## Detailed description of changes

Standard field names and items are outlined for:

Establishment type group
Establishment governance
Education phase
Establishment type
Provider type

## Checklist before requesting a review
- [ ] I have checked the contributing guidelines
- [ ] I have checked for and linked any relevant issues that this may resolve
- [ ] I have checked that these changes build locally
- [ ] I understand that if merged into main, these changes will be publicly available
