### PR TITLE
write.csv() update

### DIFF
--- a/statistics-production/ud.qmd
+++ b/statistics-production/ud.qmd
@@ -375,10 +375,10 @@ For saving results out of SQL as a .csv file there isn't an option to specify th
 
 **R**
 
-When writing .csv files out of R, you'll mostly likely be using either `write.csv()` from base R, or `write_csv()` from the readr package. For the first one, you can specify encoding using `encoding = ` like the following example:
+When writing .csv files out of R, you'll mostly likely be using either `write.csv()` from base R, or `write_csv()` from the readr package. For the first one, you can specify encoding using `fileEncoding = ` like the following example:
 
 
-`write.csv(my_data, file = "my_data_file.csv", encoding = "UTF-8")`
+`write.csv(my_data, file = "my_data_file.csv", fileEncoding = "UTF-8")`
 
 
 For `write_csv()`, which some of you may be using for increased processing speed, the function automatically encodes as UTF-8 format, meaning that you don't have to do anything different!


### PR DESCRIPTION
## Overview of changes

Quick change to example code for writing CSVs in UTF-8 encoding.

## Why are these changes being made?

I tried to use the guidance and noticed the argument is different now.

## Detailed description of changes

We previously advised using `encoding = XX`, but apparently this is now `fileEncoding =  XX`

![image](https://github.com/dfe-analytical-services/analysts-guide/assets/52536248/1a8da43c-cc82-45b0-a458-8f0154829b79)

## Issue ticket number/s and link

None

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [ ] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
