### PR TITLE
Added guidance on SSL cert errors

### DIFF
--- a/learning-development/r.qmd
+++ b/learning-development/r.qmd
@@ -592,6 +592,21 @@ Then restart R-Studio and downloads with renv should now succeed.
 
 ---
 
+### Packages not downloading (or not able to connect to other external service from within R, Python, Bash etc.) due to SSL certificate error
+
+---
+
+The DfE firewall currently blocks access to external sites from DfE laptops when 
+connecting from common analytical software such as R or Python. This can prevent
+analysts from accessing important external resources such as package 
+repositories and data API endpoints. If you get an error including text along 
+the lines of "self signed SSL certificate not allowed" or anything similar 
+involving SSL certs., then contact the [Statistics Development Team ](mailto:statistics.development@education.gov.uk) with a copy of the command
+that you're running and the error that it's producing. We can then work with the
+Network Operations team to prevent this being a blocker to your work.
+
+---
+
 ### shinytest2 - Invalid path to Chrome (chromote) error message
 
 ---

--- a/learning-development/r.qmd
+++ b/learning-development/r.qmd
@@ -592,7 +592,7 @@ Then restart R-Studio and downloads with renv should now succeed.
 
 ---
 
-### Packages not downloading (or not able to connect to other external service from within R, Python, Bash etc.) due to SSL certificate error
+### SSL certificate errors
 
 ---
 
@@ -601,9 +601,11 @@ connecting from common analytical software such as R or Python. This can prevent
 analysts from accessing important external resources such as package 
 repositories and data API endpoints. If you get an error including text along 
 the lines of "self signed SSL certificate not allowed" or anything similar 
-involving SSL certs., then contact the [Statistics Development Team ](mailto:statistics.development@education.gov.uk) with a copy of the command
-that you're running and the error that it's producing. We can then work with the
-Network Operations team to prevent this being a blocker to your work.
+involving SSL certificates (or certs.), then contact the 
+[Statistics Development Team](mailto:statistics.development@education.gov.uk) 
+with a copy of the command that you're running and the error that it's 
+producing. We can then work with the Network Operations team to prevent this 
+being a blocker to your work.
 
 ---
 


### PR DESCRIPTION
## Overview of changes

I've added a paragraph on what analysts should do if they're blocked by an SSL cert type error.