### PR TITLE
update analytics academy link to point to new SharePoint area

### DIFF
--- a/learning-development/learning-support.qmd
+++ b/learning-development/learning-support.qmd
@@ -67,7 +67,7 @@ We also have specific learning resources and materials for [SQL](../learning-dev
 
 **Google and other web-search engines are the single most powerful learning resource out there**, whether it leads you to a Stack Overflow answer to your problem, or to an online training course, it will have your needs covered. We appreciate that it can be daunting and overwhelming at first though, which is why we're pooling together links to particularly relevant resources on this page. Let us know if there's any you'd like to see added!
 
-- [The DfE Analytics Academy online R training course](https://trello.com/invite/b/QdDx3VmA/96f273b3438db2bb8ee5feae3943c3d4/analytics-academy-an-r-training-course){target="_blank" rel="noopener noreferrer"} - walks you through how to get set up with R, as well as setting tasks using DfE data to learn fundamental skills in R.
+- [The DfE Analytics Academy online R training course](https://educationgovuk.sharepoint.com/sites/AnalyticsAcademy798){target="_blank" rel="noopener noreferrer"} - walks you through how to get set up with R, as well as setting tasks using DfE data to learn fundamental skills in R.
 
 - [How to QA](https://dfe-analytical-services.github.io/how-to-qa/index.html){target="_blank" rel="noopener noreferrer"} - a general guide to quality assurance best practice in DfE.
 

--- a/learning-development/r.qmd
+++ b/learning-development/r.qmd
@@ -30,8 +30,7 @@ Download R (language) and RStudio (IDE) from the DfE software center. We also re
 
 ## Best places to start
 
-- The DfE Analytics Academy host an [online R training course on trello](https://trello.com/b/QdDx3VmA/analytics-academy-an-r-training-course){target="_blank" rel="noopener noreferrer"}. This is a great resource full of reproducible examples using DfE data. The course takes you through initially getting R downloaded, all the way through to developing apps in RShiny.\
-**Note** if you have not accessed analytics academy before, you will need to log in or create a free trello account and request access the first time you open the link, and one of the admins will approve your request. 
+- The DfE Analytics Academy host an [online R training course on SharePoint](https://educationgovuk.sharepoint.com/sites/AnalyticsAcademy798){target="_blank" rel="noopener noreferrer"}. This is a great resource full of reproducible examples using DfE data. The course takes you through initially getting R downloaded, all the way through to developing apps in RShiny.\
 
 - There is also the [DfE R training guide](https://dfe-analytical-services.github.io/r-training-course/){target="_blank" rel="noopener noreferrer"}, which is a great starting point and reference to guide you through how to get started using R and RStudio.
 


### PR DESCRIPTION
## Overview of changes
Real quick update to analytics academy link which is now hosted on SharePoint rather than trello
