### PR TITLE
RTools download from Software Centre and David Sands VPN disclaimer 

### DIFF
--- a/learning-development/git.qmd
+++ b/learning-development/git.qmd
@@ -40,7 +40,7 @@ When you first try to use Git you may be prompted for a GitHub username and pass
 
 - If you're new to Git and are unsure of what it does, then take a look through these [Git for humans slides](https://speakerdeck.com/alicebartlett/git-for-humans){target="_blank" rel="noopener noreferrer"}
 
-- David Sands' guide to [getting started with Git](https://web.microsoftstream.com/video/cc21863d-a6f8-4b53-b66c-1dfd012b8d79?list=studio){target="_blank" rel="noopener noreferrer"} is a helpful place to start.
+- David Sands' guide to [getting started with Git](https://web.microsoftstream.com/video/cc21863d-a6f8-4b53-b66c-1dfd012b8d79?list=studio){target="_blank" rel="noopener noreferrer"} is a helpful place to start. When watching video 03, do NOT run the code to change your proxy settings! Ignore this part of the video.
 
 - [Gooey Git](https://educationgovuk.sharepoint.com/sites/sarpi/g/WorkplaceDocuments/Forms/AllItems.aspx?id=%2Fsites%2Fsarpi%2Fg%2FWorkplaceDocuments%2FInducation%20learning%20and%20career%20development%2FCoffee%20and%20Coding%2F190220%5Fdavid%5Fgoeeygit%2Fgooey%5Fgit%2Ehtml&parent=%2Fsites%2Fsarpi%2Fg%2FWorkplaceDocuments%2FInducation%20learning%20and%20career%20development%2FCoffee%20and%20Coding%2F190220%5Fdavid%5Fgoeeygit){target="_blank" rel="noopener noreferrer"} by David Sands, provides a very neat overview of using git with R.
 

--- a/learning-development/r.qmd
+++ b/learning-development/r.qmd
@@ -569,11 +569,9 @@ mutated <- mutate(mtcars, new_var = wt ** 2)
 
 ---
 
-This error will appear when trying to restore old package versions using `renv::restore()`. It is usually due to Rtools not being properly installed, and therefore your system is struggling to install the older version of the package that hasn't been provided by CRAN.ware centre. 
+This error will appear when trying to restore old package versions using `renv::restore()`. It is usually due to Rtools not being properly installed, and therefore your system is struggling to install the older version of the package that hasn't been provided by CRAN. 
 
-The solution takes a few minutes, but is relatively straightforward, you can [install Rtools as a direct download from CRAN](https://cran.r-project.org/bin/windows/Rtools/). On there, pick the right version of RTools for your version of R, download the file and install.
-
-Set the install location to your c drive, for example, if installing for R4.2.2, install RTools42 to `C:\rtools42` (this is the default location).
+The solution takes a few minutes, but is relatively straightforward, you can install Rtools as a direct download from the Software Centre. On there, pick the right version of RTools for your version of R and install the application.
 
 Once it's installed close and reopen RStudio and run `renv::restore()` again - it should hopefully now restore and install your packages successfully!
 


### PR DESCRIPTION
## Overview of changes
l've changed the description in the troubleshooting section from downloading from Cran to Software Centre.
l've also added a few sentences mentioning a disclaimer on David Sands video.

## Why are these changes being made?
To help analysts get set up with git and R without issues.

## Issue ticket number/s and link
None.

## Checklist before requesting a review
- [ ] I have checked the contributing guidelines
- [ ] I have checked for and linked any relevant issues that this may resolve
- [ ] I have checked that these changes build locally
- [ ] I understand that if merged into main, these changes will be publicly available
