### PR TITLE
Add accessibility resources page

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -83,6 +83,7 @@ website:
           - learning-development/r.qmd
           - learning-development/git.qmd
           - learning-development/python.qmd
+          - learning-development/accesssibility.qmd
       - section: "Statistics production"
         contents:
           - statistics-production/pub.qmd

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -83,7 +83,7 @@ website:
           - learning-development/r.qmd
           - learning-development/git.qmd
           - learning-development/python.qmd
-          - learning-development/accesssibility.qmd
+          - learning-development/accessibility.qmd
       - section: "Statistics production"
         contents:
           - statistics-production/pub.qmd

--- a/index.qmd
+++ b/index.qmd
@@ -34,6 +34,8 @@ We hope it can prove a useful community driven resource for everyone from the mo
 [Python](learning-development/python.html)
 - Guidance and tips for using Python
 
+[Accessibility](learning-development/accessibility.html)
+- Tools and resources for digital accessibility
 
 ## Statistics production
 

--- a/learning-development/accessibility.qmd
+++ b/learning-development/accessibility.qmd
@@ -9,9 +9,14 @@ title: "Accessibility"
 
 ## Accessibility in DfE
 
+Everyone has a part to play in ensuring that the content and digital services the DfE provides to it's customers and colleagues are accessible. Everyone should have an understanding of their responsibilities to comply with the [Public Sector Bodies Accessibility Regulations 2018](https://www.legislation.gov.uk/uksi/2018/952/contents/made) and the [Web Content Accessibility Guidelines 2.2](https://www.w3.org/TR/WCAG22/). Moreover, everyone should also understand the important and critical difference this makes to the everyday lives of millions of people.
+
 DfE have our own [Digital Accessibility Hub](https://educationgovuk.sharepoint.com/sites/lvewp00043) filled with helpful information on making the digital world more accessible.
 
 There are also the [DfE design manual](https://design.education.gov.uk), which has been created by the digital teams at DfE and includes [DfE's digital accessibility guidance](https://design.education.gov.uk/accessibility).
+
+
+If you want to estimate or try to appreciate just how many people might have specific needs, there is the [How many people? tool](https://design.education.gov.uk/tools/how-many-users), simply enter how many people your audience is, and it will give you best estimates of how many people might have a disability, impairment or other characteristics which might affect how they use your service. 
 
 ---
 
@@ -24,7 +29,7 @@ Contrast:
 
 Colour blindness:
 
-- [Adobe colour accessibility (gives a pass / fail)](https://color.adobe.com/create/color-accessibility)
+- [Adobe colour accessibility (gives a pass / fail)](https://color.adobe.com/create/color-accessibility/)
 - [Coblis (simulates colour blindness for uploaded images)](https://www.color-blindness.com/coblis-color-blindness-simulator/)
 - [ColourBlindCheck (R package for simulating colour blindness for a colour palette)](https://github.com/Nowosad/colorblindcheck)
 
@@ -39,7 +44,7 @@ For more advice about colour in charts and visualisations specifically, includin
 
 ## Free tools for reviewing web pages
 
-- [axe DevTools](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?pli=1), free chrome extension and paid versions, we recommend this (and GDS tend to recommend too)
+- [axe DevTools](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?pli=1), free Google Chrome extension and paid versions, we recommend this (and GDS tend to recommend too)
 
 - [Google Lighthouse](https://developer.chrome.com/docs/lighthouse/overview), built into Google Chrome browser, and will catch some basic accessibility things amongst other web related issues
 
@@ -51,9 +56,9 @@ For more advice about colour in charts and visualisations specifically, includin
 
 No automated tools fully cover accessibility, manual testing is always required, so if you want to do manual testing have a look at testing out the assistive software commonly used by users yourself.
 
-Magnifier:
+Magnifiers / advanced zoom:
 
-- Built into Windows ([guidance for how to turn on Magnifier](https://support.microsoft.com/en-gb/windows/use-magnifier-to-make-things-on-the-screen-easier-to-see-414948ba-8b1c-d3bd-8615-0e5e32204198#:~:text=To%20quickly%20turn%20on%20Magnifier,turn%20on%20the%20Magnifier%20switch.))
+- Windows Magnifier, comes as standard with Windows ([guidance for how to turn on Magnifier](https://support.microsoft.com/en-gb/windows/use-magnifier-to-make-things-on-the-screen-easier-to-see-414948ba-8b1c-d3bd-8615-0e5e32204198#:~:text=To%20quickly%20turn%20on%20Magnifier,turn%20on%20the%20Magnifier%20switch.))
 - [ZoomText](https://www.freedomscientific.com/products/software/zoomtext/), available through the [experience lab in DfE](https://educationgovuk.sharepoint.com/sites/lvewp00043/SitePages/Experience-Lab.aspx)
 
 Screen reader:
@@ -64,6 +69,11 @@ Screen reader:
 Voice activation:
 
 - [Dragon](https://www.nuance.com/en-gb/dragon.html), available through the [experience lab in DfE](https://educationgovuk.sharepoint.com/sites/lvewp00043/SitePages/Experience-Lab.aspx)
+
+
+Cognitive load:
+
+- While there isn't commonly used specific assistive technology for aiding users in reducing cognitive load, you can take many steps to reduce the cognitive load for users on your service, making it simpler to use for all. Have a read of [Cognitive Load as a Guide: 12 Spectrums to Improve Your Data Visualisations](https://nightingaledvs.com/cognitive-load-as-a-guide-12-spectrums-to-improve-your-data-visualizations/) as a starting point if you want to learn more.
 
 Along with devices and the software mentioned above, the [experience lab in the Sheffield DfE office](https://educationgovuk.sharepoint.com/sites/lvewp00043/SitePages/Experience-Lab.aspx) also has a range of other equipment available, including access to a set of vision emulating glasses that you can wear to emulate different visual impairments.
 

--- a/learning-development/accessibility.qmd
+++ b/learning-development/accessibility.qmd
@@ -9,7 +9,7 @@ title: "Accessibility"
 
 ## Accessibility in DfE
 
-Everyone has a part to play in ensuring that the content and digital services the DfE provides to it's customers and colleagues are accessible. Everyone should have an understanding of their responsibilities to comply with the [Public Sector Bodies Accessibility Regulations 2018](https://www.legislation.gov.uk/uksi/2018/952/contents/made) and the [Web Content Accessibility Guidelines 2.2](https://www.w3.org/TR/WCAG22/). Moreover, everyone should also understand the important and critical difference this makes to the everyday lives of millions of people.
+Everyone has a part to play in ensuring that the content and digital services the DfE provides to its customers and colleagues are accessible. Everyone should have an understanding of their responsibilities to comply with the [Public Sector Bodies Accessibility Regulations 2018](https://www.legislation.gov.uk/uksi/2018/952/contents/made) and the [Web Content Accessibility Guidelines 2.2](https://www.w3.org/TR/WCAG22/). Moreover, everyone should also understand the important and critical difference this makes to the everyday lives of millions of people.
 
 DfE have our own [Digital Accessibility Hub](https://educationgovuk.sharepoint.com/sites/lvewp00043) filled with helpful information on making the digital world more accessible.
 
@@ -44,7 +44,7 @@ For more advice about colour in charts and visualisations specifically, includin
 
 ## Free tools for reviewing web pages
 
-- [axe DevTools](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?pli=1), free Google Chrome extension and paid versions, we recommend this (and GDS tend to recommend too)
+- [axe DevTools](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?pli=1), free Google Chrome extension and paid versions, we recommend this (and Government Digital Service tend to recommend too)
 
 - [Google Lighthouse](https://developer.chrome.com/docs/lighthouse/overview), built into Google Chrome browser, and will catch some basic accessibility things amongst other web related issues
 

--- a/learning-development/accessibility.qmd
+++ b/learning-development/accessibility.qmd
@@ -1,0 +1,36 @@
+---
+title: "Accessibility"
+---
+
+<p class="text-muted">Some quick links and tips for increasing awareness of accessibility in digital content</p>
+
+---
+
+Accessibility tools you can use
+
+If wanting to check anything around colour:
+	- Contrast - webaim / https://jansensan.github.io/color-contrast-matrix/
+	- Colour blindness -
+	- Colour blindness simulation - 
+	- Greyscale - 
+
+Helpful browser addins
+
+These 'bookmarklets' are bookmarks that instead of saving a URL to a page, save a piece of Javascript code that executes on the page you are looking at, usually to highlight specific mark up. Very nifty!
+
+	- Links
+
+Free accessibility tools
+	- Axe devtools, chrome extension / free download, we recommend (and I believe GDS tend to recommend too)
+	- Google Lighthouse, lowest effort, and will catch some basic things, though doesn't cover everything
+
+Worth also noting that no automated tools fully cover accessibility, manual testing is always required, so if you want to do manual testing have a look at:
+
+Screen reader
+	- NVDA (free to download)
+
+Voice activation
+	- Dragon is a paid for licence, though available through the empathy lab
+
+Magnifier
+Built into windows? Check

--- a/learning-development/accessibility.qmd
+++ b/learning-development/accessibility.qmd
@@ -4,33 +4,67 @@ title: "Accessibility"
 
 <p class="text-muted">Some quick links and tips for increasing awareness of accessibility in digital content</p>
 
+
 ---
 
-Accessibility tools you can use
+## Accessibility in DfE
 
-If wanting to check anything around colour:
-	- Contrast - webaim / https://jansensan.github.io/color-contrast-matrix/
-	- Colour blindness -
-	- Colour blindness simulation - 
-	- Greyscale - 
+DfE have our own [Digital Accessibility Hub](https://educationgovuk.sharepoint.com/sites/lvewp00043) filled with helpful information on making the digital world more accessible.
 
-Helpful browser addins
+There are also the [DfE design manual](https://design.education.gov.uk), which has been created by the digital teams at DfE and includes [DfE's digital accessibility guidance](https://design.education.gov.uk/accessibility).
 
-These 'bookmarklets' are bookmarks that instead of saving a URL to a page, save a piece of Javascript code that executes on the page you are looking at, usually to highlight specific mark up. Very nifty!
+---
 
-	- Links
+## Colour accessibility tools
 
-Free accessibility tools
-	- Axe devtools, chrome extension / free download, we recommend (and I believe GDS tend to recommend too)
-	- Google Lighthouse, lowest effort, and will catch some basic things, though doesn't cover everything
+Contrast:
 
-Worth also noting that no automated tools fully cover accessibility, manual testing is always required, so if you want to do manual testing have a look at:
+- [WebAim (comparing two colours)](https://webaim.org/resources/contrastchecker/)
+- [Colour contrast matrix (comparing multiple colours](https://jansensan.github.io/color-contrast-matrix/)
 
-Screen reader
-	- NVDA (free to download)
+Colour blindness:
 
-Voice activation
-	- Dragon is a paid for licence, though available through the empathy lab
+- [Adobe colour accessibility (gives a pass / fail)](https://color.adobe.com/create/color-accessibility)
+- [Coblis (simulates colour blindness for uploaded images)](https://www.color-blindness.com/coblis-color-blindness-simulator/)
+- [ColourBlindCheck (R package for simulating colour blindness for a colour palette)](https://github.com/Nowosad/colorblindcheck)
 
-Magnifier
-Built into windows? Check
+Grey scale:
+
+- You can often check colours in grey scale by using a print preview and switching the colour mode
+- [ColToGrey function within the DescTools R package](https://andrisignorell.github.io/DescTools/reference/ColToGrey.html)
+
+For more advice about colour in charts and visualisations specifically, including more tools and resources for checking colours yourself, see the [Analysis function colours in charts guidance](https://analysisfunction.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/#section-9).
+
+---
+
+## Free tools for reviewing web pages
+
+- [axe DevTools](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?pli=1), free chrome extension and paid versions, we recommend this (and GDS tend to recommend too)
+
+- [Google Lighthouse](https://developer.chrome.com/docs/lighthouse/overview), built into Google Chrome browser, and will catch some basic accessibility things amongst other web related issues
+
+'Bookmarklets' are bookmarks that instead of saving a URL to a page, save a piece of Javascript code that executes on the page you are looking at. There's some nice [accessibility focused bookmarklets](https://design.education.gov.uk/accessibility/assurance) that highlight specific types of mark up such as headers and lists so you can easily check if it matches what you'd expect while on any webpage. Very nifty and low effort too!
+
+---
+
+## Assistive technology
+
+No automated tools fully cover accessibility, manual testing is always required, so if you want to do manual testing have a look at testing out the assistive software commonly used by users yourself.
+
+Magnifier:
+
+- Built into Windows ([guidance for how to turn on Magnifier](https://support.microsoft.com/en-gb/windows/use-magnifier-to-make-things-on-the-screen-easier-to-see-414948ba-8b1c-d3bd-8615-0e5e32204198#:~:text=To%20quickly%20turn%20on%20Magnifier,turn%20on%20the%20Magnifier%20switch.))
+- [ZoomText](https://www.freedomscientific.com/products/software/zoomtext/), available through the [experience lab in DfE](https://educationgovuk.sharepoint.com/sites/lvewp00043/SitePages/Experience-Lab.aspx)
+
+Screen reader:
+
+- [Non-visual Desktop Access (NVDA) free download](https://www.nvaccess.org/download/)
+- [Job Access With Speech (JAWS)](https://www.freedomscientific.com/products/software/jaws/), available through the [experience lab in DfE](https://educationgovuk.sharepoint.com/sites/lvewp00043/SitePages/Experience-Lab.aspx)
+
+Voice activation:
+
+- [Dragon](https://www.nuance.com/en-gb/dragon.html), available through the [experience lab in DfE](https://educationgovuk.sharepoint.com/sites/lvewp00043/SitePages/Experience-Lab.aspx)
+
+Along with devices and the software mentioned above, the [experience lab in the Sheffield DfE office](https://educationgovuk.sharepoint.com/sites/lvewp00043/SitePages/Experience-Lab.aspx) also has a range of other equipment available, including access to a set of vision emulating glasses that you can wear to emulate different visual impairments.
+
+---

--- a/learning-development/sql.qmd
+++ b/learning-development/sql.qmd
@@ -42,7 +42,7 @@ Andy Brook's excellent Introduction to SQL session, giving a visual overview of 
 
 ## Best practice
 
-Here are some tips to follow best practice in your SQL code, making it easier to read and pick up if another person is running your code. Following best practice guidance will help you to achieve RAP best practice with [clean final code](../RAP/rap.html#Clean_final_code)
+Here are some tips to follow best practice in your SQL code, making it easier to read and pick up if another person is running your code. Following best practice guidance will help you to achieve RAP best practice with [clean final code](../RAP/rap-statistics.html#clean-final-code).
 
 * Avoid any trailing whitespace
 * Always capitalize SQL keywords (e.g., SELECT or AS)

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.3.3",
+    "Version": "4.4.1",
     "Repositories": [
       {
         "Name": "CRAN",


### PR DESCRIPTION
## Overview of changes

Add a new accessibility tools and guidance page in the learning resources section

## Why are these changes being made?

Request by an analyst for a list of free tools to get started with, expanded into making this page so it's available for everyone and we can build it up over time too.

## Detailed description of changes

1. New accessibility resources page
2. Updated renv snapshot to latest R version
3. Fix broken link to RAP pages from SQL page

## Issue ticket number/s and link

Fixes #54 

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
