### PR TITLE
swap sdt for ees mailbox on ees / dashboards pages

### DIFF
--- a/statistics-production/ees.qmd
+++ b/statistics-production/ees.qmd
@@ -789,7 +789,7 @@ We recommend including any missing data from breaks in a time series in your dat
 | Number of schools | 16,705 | 16,723 | 16,736 | x | 16,739 |
 
 <div class="alert alert-dismissible alert-info">
-There may be times when including missing data increases the file size too much, or becomes unwieldy, if you're unsure and would like advice on your data contact [statistics.development@education.gov.uk](mailto:statistics.development@education.gov.uk).
+There may be times when including missing data increases the file size too much, or becomes unwieldy, if you're unsure and would like advice on your data contact [explore.statistics@education.gov.uk](mailto:explore.statistics@education.gov.uk).
 </div>
 
 By including the missing data in your open data files you can then create charts in EES that represent this. Start off by creating a data block with the data you want to build the chart from.
@@ -1002,7 +1002,7 @@ If you need some steer on how to report on a particular characteristics, the bel
 * [Analysis Function Data Harmonisation](https://analysisfunction.civilservice.gov.uk/policy-store/ethnicity-harmonised-standard/)
 * [Cabinet Office guidance on writing about statistics](https://www.ethnicity-facts-figures.service.gov.uk/style-guide/writing-about-ethnicity)
 
-You can also get in touch with the DfE Data Harmonisation Champions Group via [statistics.development@education.gov.uk](mailto:statistics.development@education.gov.uk).
+You can also get in touch with the DfE Data Harmonisation Champions Group via [explore.statistics@education.gov.uk](mailto:explore.statistics@education.gov.uk).
 
 ---
 

--- a/statistics-production/embedded-charts.qmd
+++ b/statistics-production/embedded-charts.qmd
@@ -47,7 +47,7 @@ We currently only support custom charts created using R-Shiny. These should be c
 ## Review and authorisation
 
 
-To get a custom chart approved for embedding within a publication, you'll need to get it reviewed by the [Statistics Development team](mailto:statistics.development@education.gov.uk) (in addition to your standard approval chain).
+To get a custom chart approved for embedding within a publication, you'll need to get it reviewed by the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk) (in addition to your standard approval chain).
 
 ---
 
@@ -61,7 +61,7 @@ An embedded chart should take the form of a single chart, with necessary input o
 * using navigation elements
 * images and logos
 
-**And definitely don't include unpublished data in any app uploaded to GitHub/ShinyApps prior to publication.**
+**And definitely don't include unpublished data in any app uploaded to GitHub / ShinyApps prior to publication.**
 
 Other elements such as tables may also be possible if there's a clear use case for them that EES alone can't meet. Get in touch with us if you want to check that what you'd like to include is compatible with the intended use of the embed block.
 
@@ -72,7 +72,7 @@ Other elements such as tables may also be possible if there's a clear use case f
 
 Our [template tiny shiny app repository](https://github.com/dfe-analytical-services/dfe-tiny-shiny) should be used a starting point for all embedded shiny charts.
 
-To get an app set-up for use with EES, you'll need the [Statistics Development Team](mailto:statistics.development@education.gov.uk) team to create a repo for the app within the [DfE Analytical Services area on GitHub](https://github.com/dfe-analytical-services/dfe-tiny-shiny).
+To get an app set-up for use with EES, you'll need the [explore education statistics platforms](mailto:explore.statistics@education.gov.uk) team to create a repo for the app within the [DfE Analytical Services area on GitHub](https://github.com/dfe-analytical-services/dfe-tiny-shiny).
 
 ---
 

--- a/statistics-production/scrums.qmd
+++ b/statistics-production/scrums.qmd
@@ -21,7 +21,7 @@ All of our publications should be designed around our users first and foremost, 
 
 We regularly run publication scrums where teams can put forward their publication(s) for review by a group of volunteer analysts, providing feedback as ‘unfamiliar new readers’ and to discuss ideas for future improvements. The sessions usually last for 1-2 hours.
 
-If you're interested in being involved in future scrums, please get in [contact us](mailto:statistics.development@education.gov.uk).
+If you're interested in being involved in future scrums, please get in [contact us](mailto:explore.statistics@education.gov.uk).
 
 ---
 

--- a/statistics-production/scrums.qmd
+++ b/statistics-production/scrums.qmd
@@ -21,7 +21,7 @@ All of our publications should be designed around our users first and foremost, 
 
 We regularly run publication scrums where teams can put forward their publication(s) for review by a group of volunteer analysts, providing feedback as ‘unfamiliar new readers’ and to discuss ideas for future improvements. The sessions usually last for 1-2 hours.
 
-If you're interested in being involved in future scrums, please get in [contact us](mailto:explore.statistics@education.gov.uk).
+If you're interested in being involved in future scrums, please [contact us](mailto:explore.statistics@education.gov.uk).
 
 ---
 

--- a/statistics-production/ud.qmd
+++ b/statistics-production/ud.qmd
@@ -32,7 +32,7 @@ Data published via EES is released under the terms of the [Open Government Licen
 
 An [interactive data screener](https://rsconnect/rsc/dfe-published-data-qa/){target="_blank" rel="noopener noreferrer"} has been developed in R Shiny to automate checks against the standards as a final stage of automated quality assurance before upload to EES.
 
-This can be run on any data file, though requires an associated [EES metadata file](#ees-metadata) to be able to process the file. The app runs on our Posit Connect (formerly RSConnect) servers, and is only available when using DfE kit. The app is mostly self-explanatory, though if you have any questions about it, or are curious to know more about how it works, the code is available on [GitHub](https://github.com/dfe-analytical-services/dfe-published-data-qa){target="_blank" rel="noopener noreferrer"}, and you can get in touch with us at statistics.development@education.gov.uk.
+This can be run on any data file, though requires an associated [EES metadata file](#ees-metadata) to be able to process the file. The app runs on our Posit Connect (formerly RSConnect) servers, and is only available when using DfE kit. The app is mostly self-explanatory, though if you have any questions about it, or are curious to know more about how it works, the code is available on [GitHub](https://github.com/dfe-analytical-services/dfe-published-data-qa){target="_blank" rel="noopener noreferrer"}, and you can get in touch with us at explore.statistics@education.gov.uk.
 
 <div class="alert alert-dismissible alert-danger">
   All data and EES metadata files must be run through the [screening app](https://rsconnect/rsc/dfe-published-data-qa/){target="_blank" rel="noopener noreferrer"} before uploading to EES.
@@ -423,7 +423,7 @@ A **rough guide** to file size would be:
 - 500mb and over are very large, and sometimes may struggle to compress small enough to upload.
 - 4gb or more in size is larger than any we have seen before and will likely need testing in the platform first.
 
-[Contact us](mailto:mailto:statistics.development@education.gov.uk) if you have any issues, or files that might be over 1gb.
+[Contact us](mailto:mailto:explore.statistics@education.gov.uk) if you have any issues, or files that might be over 1gb.
 
 ---
 
@@ -536,7 +536,7 @@ Across every single dataset of official statistics produced by DfE, the followin
 
 We use the two columns, time_period and time_identifier, to generalise time across our underlying datasets. All data files must contain these. This is a important for general useability of our data, as well as being critical in driving the charts and tables in the explore education statistics service and making explicit reference to the time in which our measurements relate to. This is a compulsory element of any official statistics dataset.
 
-If you think that your data can't follow this format, please contact statistics.development@education.gov.uk with details so that we can discuss this.
+If you think that your data can't follow this format, please contact explore.statistics@education.gov.uk with details so that we can discuss this.
 
 
 - time_period must contain either a four digit year, or a 6 digit year.
@@ -760,7 +760,7 @@ For Planning area and Institution data, any data files that **only** consist of 
 
 
 <div class="alert alert-dismissible alert-warning">
-  If you have a level that isn’t covered above, please contact statistics.development@education.gov.uk with details and example data.
+  If you have a level that isn’t covered above, please contact explore.statistics@education.gov.uk with details and example data.
 </div>
 
 ---

--- a/statistics-production/ud.qmd
+++ b/statistics-production/ud.qmd
@@ -417,13 +417,13 @@ Excel has a cell character limit of 32,760 and a row limit of 1,048,576. It is b
 
 A **rough guide** to file size would be:
 
-- Anything under 10mb is relatively small
-- 10mb to 100mb is a fairly common file size that most teams have
-- 100mb to 500mb is a large file and will struggle to upload if not compressed to a zip folder.
-- 500mb and over are very large, and sometimes may struggle to compress small enough to upload.
-- 4gb or more in size is larger than any we have seen before and will likely need testing in the platform first.
+- Anything under 10 MB is relatively small
+- 10 MB to 100 MB is a fairly common file size that most teams have
+- 100 MB to 500 MB is a large file and will struggle to upload if not compressed to a zip folder.
+- 500 MB and over are very large, and sometimes may struggle to compress small enough to upload.
+- 4 GB or more in size is larger than any we have seen before and will likely need testing in the platform first.
 
-[Contact us](mailto:explore.statistics@education.gov.uk) if you have any issues, or files that might be over 1gb.
+[Contact us](mailto:explore.statistics@education.gov.uk) if you have any issues, or files that might be over 1 GB.
 
 ---
 

--- a/statistics-production/ud.qmd
+++ b/statistics-production/ud.qmd
@@ -423,7 +423,7 @@ A **rough guide** to file size would be:
 - 500mb and over are very large, and sometimes may struggle to compress small enough to upload.
 - 4gb or more in size is larger than any we have seen before and will likely need testing in the platform first.
 
-[Contact us](mailto:mailto:explore.statistics@education.gov.uk) if you have any issues, or files that might be over 1gb.
+[Contact us](mailto:explore.statistics@education.gov.uk) if you have any issues, or files that might be over 1gb.
 
 ---
 
@@ -536,7 +536,7 @@ Across every single dataset of official statistics produced by DfE, the followin
 
 We use the two columns, time_period and time_identifier, to generalise time across our underlying datasets. All data files must contain these. This is a important for general useability of our data, as well as being critical in driving the charts and tables in the explore education statistics service and making explicit reference to the time in which our measurements relate to. This is a compulsory element of any official statistics dataset.
 
-If you think that your data can't follow this format, please contact explore.statistics@education.gov.uk with details so that we can discuss this.
+If you think that your data can't follow this format, please contact the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk) with details so that we can discuss this further.
 
 
 - time_period must contain either a four digit year, or a 6 digit year.
@@ -760,7 +760,7 @@ For Planning area and Institution data, any data files that **only** consist of 
 
 
 <div class="alert alert-dismissible alert-warning">
-  If you have a level that isn’t covered above, please contact explore.statistics@education.gov.uk with details and example data.
+  If you have a level that isn’t covered above, please contact the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk) with details and example data.
 </div>
 
 ---

--- a/writing-visualising/dashboards.qmd
+++ b/writing-visualising/dashboards.qmd
@@ -10,9 +10,9 @@ title: "Public dashboards"
 
 ---
 
-The primary route for publishing official statistics is via [Explore education etatistics](https://explore-education-statistics.service.gov.uk/) (EES). In addition to publishing on EES, there may be times where you want to compliment official statistics with a dashboard. This may be to do a deeper piece of analysis for a specific user group, or to make use of functionality that isn’t available within the platform.
+The primary route for publishing official statistics is using the [explore education statistics service](https://explore-education-statistics.service.gov.uk/) (EES). In addition to publishing on EES, there may be times where you want to compliment official statistics with a dashboard. This may be to do a deeper piece of analysis for a specific user group, or to make use of functionality that isn’t available within the platform.
 
-It is important that all dashboards should have a clear use case and reasoning for why they are required. If you are considering developing and publishing a dashboard, please get in touch with the [Statistics Development Team](mailto:statistics.development@education.gov.uk) who can advise and assist with the process, and make use of the [teams channel](https://teams.microsoft.com/l/channel/19%3a35fa27cbced34928a3609e41510057e5%40thread.skype/R-Shiny%2520Statistics%2520Dashboards?groupId=679b2376-8c8c-4062-a1c9-0744ce5ac88f&tenantId=fad277c9-c60a-4da1-b5f3-b3b8b34a82f9) to ask questions and share what you're working on with other teams.
+It is important that all dashboards should have a clear use case and reasoning for why they are required. If you are considering developing and publishing a dashboard, please get in touch with the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk) who can advise and assist with the process, and make use of the [teams channel](https://teams.microsoft.com/l/channel/19%3a35fa27cbced34928a3609e41510057e5%40thread.skype/R-Shiny%2520Statistics%2520Dashboards?groupId=679b2376-8c8c-4062-a1c9-0744ce5ac88f&tenantId=fad277c9-c60a-4da1-b5f3-b3b8b34a82f9) to ask questions and share what you're working on with other teams.
 
 This guidance is aimed primarily at dashboards published to supplement Official Statistics to the wider public. See the [how to publish an R shiny dashboard](#how-to-publish-an-r-shiny-dashboard) section below for more information on the guidance for internal only R Shiny dashboards, or public facing R Shiny dashboards via shinyapps.io.
 
@@ -28,7 +28,7 @@ There is also a dashboards version of the content design checklist. This checkli
 
 We expect all dashboards to follow a minimum set of standards to ensure coherence between our products and a minimum standard of quality for our end users.
 
-These standards are constantly evolving, and all feedback and contributions are welcome, contact us at [Statistics Development Team](mailto:statistics.development@education.gov.uk).
+These standards are constantly evolving, and all feedback and contributions are welcome, contact the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk).
 
 All dashboards should have a clear use case and reasoning for why they are required. They also need to meet the [latest accessibility regulations](https://www.gov.uk/service-manual/helping-people-to-use-your-service/understanding-wcag) for public sector services.
 
@@ -52,7 +52,7 @@ The following sections cover the considerations in more detail, though when deve
 
 ---
 
-All teams developing dashboards to accompany Official Statistics should contact the [Statistics Development Team](mailto:statistics.development@education.gov.uk) for advice on the level of approval required as there may be times when HoP approval is needed in addition to team / unit leader approval. Approvals should be sent to the Statistics Development Team when asking for a new dashboard to be hosted on shinyapps.io.
+All teams developing dashboards to accompany Official Statistics should contact the [explore education statistics platforms team](mailto:exp@education.gov.uk) for advice on the level of approval required as there may be times when HoP approval is needed in addition to team / unit leader approval. Approvals should be sent to the Statistics Development Team when asking for a new dashboard to be hosted on shinyapps.io.
 
 The standards for dashboards, and department strategy are maintained by the Central Statistics Standards Unit and governed by the Statistics Leadership Group, which is made up of all senior statisticians owning Official Statistics publications in the department.
 

--- a/writing-visualising/dashboards.qmd
+++ b/writing-visualising/dashboards.qmd
@@ -12,7 +12,7 @@ title: "Public dashboards"
 
 The primary route for publishing official statistics is using the [explore education statistics service](https://explore-education-statistics.service.gov.uk/) (EES). In addition to publishing on EES, there may be times where you want to compliment official statistics with a dashboard. This may be to do a deeper piece of analysis for a specific user group, or to make use of functionality that isn’t available within the platform.
 
-It is important that all dashboards should have a clear use case and reasoning for why they are required. If you are considering developing and publishing a dashboard, please get in touch with the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk) who can advise and assist with the process, and make use of the [teams channel](https://teams.microsoft.com/l/channel/19%3a35fa27cbced34928a3609e41510057e5%40thread.skype/R-Shiny%2520Statistics%2520Dashboards?groupId=679b2376-8c8c-4062-a1c9-0744ce5ac88f&tenantId=fad277c9-c60a-4da1-b5f3-b3b8b34a82f9) to ask questions and share what you're working on with other teams.
+It is important that all dashboards should have a clear use case and reasoning for why they are required. If you are considering developing and publishing a dashboard, please get in touch with the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk) who can advise and assist with the process, and make use of the [R Shiny statistics dashboards Microsoft Teams channel](https://teams.microsoft.com/l/channel/19%3a35fa27cbced34928a3609e41510057e5%40thread.skype/R-Shiny%2520Statistics%2520Dashboards?groupId=679b2376-8c8c-4062-a1c9-0744ce5ac88f&tenantId=fad277c9-c60a-4da1-b5f3-b3b8b34a82f9) to ask questions and share what you're working on with other teams.
 
 This guidance is aimed primarily at dashboards published to supplement Official Statistics to the wider public. See the [how to publish an R shiny dashboard](#how-to-publish-an-r-shiny-dashboard) section below for more information on the guidance for internal only R Shiny dashboards, or public facing R Shiny dashboards via shinyapps.io.
 
@@ -52,7 +52,7 @@ The following sections cover the considerations in more detail, though when deve
 
 ---
 
-All teams developing dashboards to accompany Official Statistics should contact the [explore education statistics platforms team](mailto:exp@education.gov.uk) for advice on the level of approval required as there may be times when HoP approval is needed in addition to team / unit leader approval. Approvals should be sent to the Statistics Development Team when asking for a new dashboard to be hosted on shinyapps.io.
+All teams developing dashboards to accompany Official Statistics should contact the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk) for advice on the level of approval required as there may be times when HoP approval is needed in addition to team / unit leader approval. Approvals should be sent to the Statistics Development Team when asking for a new dashboard to be hosted on shinyapps.io.
 
 The standards for dashboards, and department strategy are maintained by the Central Statistics Standards Unit and governed by the Statistics Leadership Group, which is made up of all senior statisticians owning Official Statistics publications in the department.
 

--- a/writing-visualising/dashboards_rshiny.qmd
+++ b/writing-visualising/dashboards_rshiny.qmd
@@ -176,7 +176,7 @@ Given the above, all analysts intending to create a dashboard should ensure they
 
 Public facing DfE Shiny applications are currently published via the DfE Analytical Services [shinyapps.io](https://www.shinyapps.io/) account, with the authorisation and deployment of dashboards performed using GitHub. 
 
-You need to alert the Statistics Development Team of any new dashboard publication as early in development as possible and keep us updated on the expected publication date so that we can review the dashboard against DfE standards and set up and support on the deployment to ShinyApps.io. In addition, please notify us of any planned data updates or significant functional updates (at least 2 weeks before publication but preferably as soon as you know any updates are required).
+You need to alert the explore education statistics platforms team of any new dashboard publication as early in development as possible and keep us updated on the expected publication date so that we can review the dashboard against DfE standards and set up and support on the deployment to ShinyApps.io. In addition, please notify us of any planned data updates or significant functional updates (at least 2 weeks before publication but preferably as soon as you know any updates are required).
 
 All dashboard publications and major updates need authorisation from the relevant G6 or DD and the stats development team (with the former authorisation e-mail being forwarded on to the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk)).
 
@@ -189,7 +189,7 @@ You will need:
 * Approval from your DD
 * If the data underlying the dashboard is currently unpublished, you will need to create dummy data to use in GitHub until the data becomes published (see [dummy data guidance](#using-dummy-data) section).
 
-To set up a new app, send the above to [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk). If your code is not yet hosted in the dfe-analytical-services area you can request for the repository to be moved at the same time as sending approvals.
+To set up a new app, send the above to [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk). If your code is not yet hosted in the [dfe-analytical-services GitHub area](https://github.com/dfe-analytical-services) you can request for the repository to be moved at the same time as sending approvals.
 
 
 ---
@@ -201,7 +201,7 @@ This checklist outlines the standard procedure for teams who are wishing to prod
 Getting set up:
 
 * Create an account on [GitHub](https://github.com/)
-* Ask the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk) to create you a repository in the [DfE analytical services area](https://github.com/dfe-analytical-services), providing the name of the dashboard and the GitHub accounts of anyone who will be contributing to the code. You should aim to have two analysts working on the code development and a line manager for review purposes. Further colleagues with review responsibilities (policy colleagues, G6 and above, etc.) can be given access to a demo-site, rather than the repository (see guidance for this below in 'Setting up a development / demo dashboard area').
+* Ask the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk) to create you a repository in the [DfE analytical services area](https://github.com/dfe-analytical-services), providing the name of the dashboard and the GitHub accounts of anyone who will be contributing to the code. You should aim to have two analysts working on the code development and a line manager for review purposes. Further colleagues with review responsibilities (policy colleagues, G6 and above, etc.) can be given access to a demo-site, rather than the repository.
 * Clone the repo to your device so you can develop your code. Open the repo page in GitHub, click the green 'Code' button, and copy the URL it provides. Then, open R Studio on your device, click file > new project > version control > Git, paste the repository URL you copied from GitHub, give your local project area a name, and choose where to save it (i.e. on your computer's C:\ drive, outside of the OneDrive-synced folders).
 
 Once you're set up, there are certain parts of the code you need to update:
@@ -221,10 +221,10 @@ You must contact the Statistics Development Team for the following:
 Setting up a development / demo dashboard area:
 
 * While developing your dashboard, you may want a private, demo-version to share with policy or senior colleagues for review and feedback. This version must use either published data or dummy data and can not use unpublished data, since this cannot be uploaded to GitHub until the day of publication (see our [dummy data guidance](#using-dummy-data) for public dashboards).
-* Ensure that prior to contacting the Statistics Development Team, you have updated all of the URL's and other items listed above.
+* Ensure that prior to contacting the explore education statistics platforms team, you have updated all of the URL's and other items listed above.
 * You must contact the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk) to add the shinyapps.io secret and token to your GitHub repo, therefore enabling the app to be hosted on shinyapps.io. Once this is done you will have a browser link you can use to access the dashboard. We can make this private such that there is a list of approved viewers who must log in to view the dashboard - please provide the email addresses of any colleagues who you wish to have access to the private version during development.
 
-You must have done the following before a dashboard can be published (the Statistics Development Team must review and approve that these have been met):
+You must have done the following before a dashboard can be published (the explore education statistics platforms team must review and approve that these have been met):
 
 * Accessibility testing the dashboard and updating the accessibility statement. The [accessibility testing guidance](#accessibility-testing) later in this section outlines how teams can do this.
 * You should test how your dashboard appears and performs on mobile devices. you can do this by opening your dashboard in chrome/edge, right clicking anywhere on the page and selecting 'inspect'. you will then see a new panel on the right hand side of your screen. To see your dashboard how a mobile user would, click the mobile/tablet button (see the image below).
@@ -392,7 +392,7 @@ Adding the file name alone will ensure it is ignored no matter where in the proj
 
 This [.GitIgnore guidance page](https://linuxize.com/post/gitignore-ignoring-files-in-git/#:~:text=.gitignore%20is%20a%20plain%20text%20file%20in%20which,a%20single%20backslash%20%28%29%20to%20escape%20the%20character.) has great guidance on how you can utilize wildcards to capture all the files you might want to ignore.
 
-If you have any questions on this process please do contact us at [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk).
+If you have any questions on this process, please contact the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk).
 
 ---
 

--- a/writing-visualising/dashboards_rshiny.qmd
+++ b/writing-visualising/dashboards_rshiny.qmd
@@ -160,12 +160,12 @@ As with charts, be careful when choosing colours, and make sure that colours hav
 Analysts should not use their own private GitHub accounts for the development of DfE dashboards.
 </div>
 
-All published dashboards should have their code hosted on the [dfe-analytical-services project on GitHub](https://github.com/dfe-analytical-services/), both for full public transparency and to enable automated approval-based deployments to the DfE publication platform. For the purposes of the internal-only review of dashboards under development, analysts may also benefit from a hosting code on the DfE Azure based DevOps platform. For both of the above, analysts should contact the [Statistics Development Team](mailto:statistics.development@education.gov.uk).
+All published dashboards should have their code hosted on the [dfe-analytical-services project on GitHub](https://github.com/dfe-analytical-services/), both for full public transparency and to enable automated approval-based deployments to the DfE publication platform. For the purposes of the internal-only review of dashboards under development, analysts may also benefit from a hosting code on the DfE Azure based DevOps platform. For both of the above, analysts should contact the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk).
 
 Given the above, all analysts intending to create a dashboard should ensure they have a good working understanding of Git, GitHub and Azure DevOps. We strongly recommend our [Tech Skills workshop on Git and Azure DevOps](../learning-development/learning-support.html#technical-workshops) to either get you started or refresh your memory.
 
 <div class="alert alert-dismissible alert-danger">
-  Be sure to read the guidance carefully, **do not** commit or push unpublished data to a GitHub repo before the day of the publication of the data. If you think you may have done this by accident, contact [Statistics Development Team](mailto:statistics.development@education.gov.uk) immediately with the full details of what has been uploaded to GitHub and when.
+  Be sure to read the guidance carefully, **do not** commit or push unpublished data to a GitHub repo before the day of the publication of the data. If you think you may have done this by accident, contact [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk) immediately with the full details of what has been uploaded to GitHub and when.
 </div>
 
 ---
@@ -178,7 +178,7 @@ Public facing DfE Shiny applications are currently published via the DfE Analyti
 
 You need to alert the Statistics Development Team of any new dashboard publication as early in development as possible and keep us updated on the expected publication date so that we can review the dashboard against DfE standards and set up and support on the deployment to ShinyApps.io. In addition, please notify us of any planned data updates or significant functional updates (at least 2 weeks before publication but preferably as soon as you know any updates are required).
 
-All dashboard publications and major updates need authorisation from the relevant G6 or DD and the stats development team (with the former authorisation e-mail being forwarded on to the [Statistics Development Team](mailto:statistics.development@education.gov.uk)).
+All dashboard publications and major updates need authorisation from the relevant G6 or DD and the stats development team (with the former authorisation e-mail being forwarded on to the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk)).
 
 The majority of dashboards made to support and augment our Official Statistics will be public facing. For public facing shiny apps you should publish via shinyapps.io. The Statistics Development Team manage a subscription for this and can help you get set up.
 
@@ -189,7 +189,7 @@ You will need:
 * Approval from your DD
 * If the data underlying the dashboard is currently unpublished, you will need to create dummy data to use in GitHub until the data becomes published (see [dummy data guidance](#using-dummy-data) section).
 
-To set up a new app, send the above to [Statistics Development Team](mailto:statistics.development@education.gov.uk). If your code is not yet hosted in the dfe-analytical-services area you can request for the repository to be moved at the same time as sending approvals.
+To set up a new app, send the above to [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk). If your code is not yet hosted in the dfe-analytical-services area you can request for the repository to be moved at the same time as sending approvals.
 
 
 ---
@@ -201,7 +201,7 @@ This checklist outlines the standard procedure for teams who are wishing to prod
 Getting set up:
 
 * Create an account on [GitHub](https://github.com/)
-* Ask the [Statistics Development Team](mailto:statistics.development@education.gov.uk) to create you a repository in the [DfE analytical services area](https://github.com/dfe-analytical-services), providing the name of the dashboard and the GitHub accounts of anyone who will be contributing to the code. You should aim to have two analysts working on the code development and a line manager for review purposes. Further colleagues with review responsibilities (policy colleagues, G6 and above, etc.) can be given access to a demo-site, rather than the repository (see guidance for this below in 'Setting up a development / demo dashboard area').
+* Ask the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk) to create you a repository in the [DfE analytical services area](https://github.com/dfe-analytical-services), providing the name of the dashboard and the GitHub accounts of anyone who will be contributing to the code. You should aim to have two analysts working on the code development and a line manager for review purposes. Further colleagues with review responsibilities (policy colleagues, G6 and above, etc.) can be given access to a demo-site, rather than the repository (see guidance for this below in 'Setting up a development / demo dashboard area').
 * Clone the repo to your device so you can develop your code. Open the repo page in GitHub, click the green 'Code' button, and copy the URL it provides. Then, open R Studio on your device, click file > new project > version control > Git, paste the repository URL you copied from GitHub, give your local project area a name, and choose where to save it (i.e. on your computer's C:\ drive, outside of the OneDrive-synced folders).
 
 Once you're set up, there are certain parts of the code you need to update:
@@ -222,7 +222,7 @@ Setting up a development / demo dashboard area:
 
 * While developing your dashboard, you may want a private, demo-version to share with policy or senior colleagues for review and feedback. This version must use either published data or dummy data and can not use unpublished data, since this cannot be uploaded to GitHub until the day of publication (see our [dummy data guidance](#using-dummy-data) for public dashboards).
 * Ensure that prior to contacting the Statistics Development Team, you have updated all of the URL's and other items listed above.
-* You must contact the [Statistics Development Team](mailto:statistics.development@education.gov.uk) to add the shinyapps.io secret and token to your GitHub repo, therefore enabling the app to be hosted on shinyapps.io. Once this is done you will have a browser link you can use to access the dashboard. We can make this private such that there is a list of approved viewers who must log in to view the dashboard - please provide the email addresses of any colleagues who you wish to have access to the private version during development.
+* You must contact the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk) to add the shinyapps.io secret and token to your GitHub repo, therefore enabling the app to be hosted on shinyapps.io. Once this is done you will have a browser link you can use to access the dashboard. We can make this private such that there is a list of approved viewers who must log in to view the dashboard - please provide the email addresses of any colleagues who you wish to have access to the private version during development.
 
 You must have done the following before a dashboard can be published (the Statistics Development Team must review and approve that these have been met):
 
@@ -250,7 +250,7 @@ Note that wherever possible dashboard development updates should be done separat
 
 ---
 
-- Contact the [Statistics Development Team](mailto:statistics.development@education.gov.uk) providing the following:
+- Contact the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk) providing the following:
   - brief outline of the planned changes
   - a planned publication date and time for the dashboard
   - the contact details of the lead developer
@@ -392,7 +392,7 @@ Adding the file name alone will ensure it is ignored no matter where in the proj
 
 This [.GitIgnore guidance page](https://linuxize.com/post/gitignore-ignoring-files-in-git/#:~:text=.gitignore%20is%20a%20plain%20text%20file%20in%20which,a%20single%20backslash%20%28%29%20to%20escape%20the%20character.) has great guidance on how you can utilize wildcards to capture all the files you might want to ignore.
 
-If you have any questions on this process please do contact us at [Statistics Development Team](mailto:statistics.development@education.gov.uk).
+If you have any questions on this process please do contact us at [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk).
 
 ---
 
@@ -425,7 +425,7 @@ If you're running the app from an internal database, you'll need to contact the 
 
 ---
 
-If you're planning to publish a dashboard, or to set up Google Analytics for a published dashboard, please contact the [Statistics Development Team](mailto:statistics.development@education.gov.uk).
+If you're planning to publish a dashboard, or to set up Google Analytics for a published dashboard, please contact the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk).
 
 The template has a google_analytics.html file which is set up to track all basic metrics, plus the inputs from both drop-downs. To set this up with your own app you will need a new tracking tag (the long number in the gtag()) which the Statistics Development Team can provide you with. Please contact us in order to set this up.
 


### PR DESCRIPTION
## Overview of changes
Swap the mailboxes from SDT to EES

## Why are these changes being made?
The team has split so we're now splitting the responsibilities for each mailbox more clearly

## Detailed description of changes
Changed a bunch of EES and dashboard pages, left the overall references as Jen / SDT are the overall owner, and also the references in learning resources and RAP sections as they sit with SDT

Places where references to SDT mailbox still exist:

![image](https://github.com/user-attachments/assets/f7352846-3a59-4d61-b170-5f7339b1771d)


## Issue ticket number/s and link
Resolves #65 

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
