### PR TITLE
Adding first draft of the API data standards

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -89,6 +89,7 @@ website:
           - statistics-production/pub.qmd
           - RAP/rap-statistics.qmd
           - statistics-production/ud.qmd
+          - statistics-production/api-data-standards.qmd
           - statistics-production/ees.qmd
           - statistics-production/examples.qmd
           - statistics-production/embedded-charts.qmd

--- a/statistics-production/api-data-standards.qmd
+++ b/statistics-production/api-data-standards.qmd
@@ -30,7 +30,9 @@ Examples of these that do and don't meet the API data standards are provided in 
 
 ## Tidy data structure
 
-The key thing on tidy data structure is to avoid filter items being included within indicator col_names. Where you have collections of related terms appearing in indicator names (e.g. male, female, total), then these should be translated into a filter column, with the data being pivoted.
+The key thing on tidy data structure is to avoid filter items being included within indicator col_names. Where 
+you have collections of related terms appearing in indicator names (e.g. male, female, total), then these 
+should be translated into a filter column, with the data being pivoted.
 
 ### Example 1 - Attainment rates and scores
 
@@ -131,4 +133,20 @@ Areas which are currently under development are:
 - free school meal status
 
 We encourage contributions to and feedback on all of the above and any other filter topic.
+
+### Examples of common non-standard col_names
+
+::: {.table-responsive}
+
+| Non-standard                | Potential standard equivalents   |
+|-----------------------------|----------------------------------|
+| ethnicity                   | ethnicity_major, ethnicity_minor |
+| sex_pupils                  | sex                              |
+| school_type                 | establishment_type, establishment_type_group or education_phase |
+| pupil_sen_status            | sen_status                       |
+| characteristic_primary_need | sen_primary_need                 |
+
+: Example non-standard col_names and their potential equivalents in the standardised framework.
+
+:::
 

--- a/statistics-production/api-data-standards.qmd
+++ b/statistics-production/api-data-standards.qmd
@@ -134,7 +134,7 @@ Areas which are currently under development are:
 
 We encourage contributions to and feedback on all of the above and any other filter topic.
 
-### Examples of common non-standard col_names
+### Examples of common non-standard filter col_names
 
 ::: {.table-responsive}
 
@@ -152,3 +152,40 @@ We encourage contributions to and feedback on all of the above and any other fil
 
 :::
 
+## Standardised indicator col_names
+
+Indicators should be named in line with the [indicator naming conventions set out in the open data standards](../statistics-production/ud.html#indicator-names).
+
+### Examples of common non-standard indicator col_names
+
+::: {.table-responsive}
+
+| Non-standard                           | Potential standard equivalents           |
+|----------------------------------------|------------------------------------------|
+| number_of_pupils                       | pupil_count                              |
+| NumberOfLearners, NumLearners          | pupil_count, learner_count               |
+| total_male, total_female               | pupil_count (plus sex filter)            |
+| pt_SEN_support                         | pupil_percent (plus SEN status filter)   |
+| num_provider, num_providers            | establishment_count                      |
+| no_schools, num_schools, total_schools | establishment_count                      |
+| num_inst, total_institutions, number_institutions, inst_count | establishment_count |
+
+: Example non-standard indicator col_names and their potential equivalents in the standardised framework.
+
+:::
+
+## Character limits for col_names and filter items
+
+Character limits for fields in data uploaded to the API are:
+
+::: {.table-responsive}
+
+| Element                         | Character limit |
+|---------------------------------|-----------------|
+|Filter / indicator column names  | 50 characters   |
+|Filter / indicator column labels | 80 characters   |
+|Filter items / location names    | 120 characters  |
+
+: Character limits on column names, column labels and filter items.
+
+:::

--- a/statistics-production/api-data-standards.qmd
+++ b/statistics-production/api-data-standards.qmd
@@ -138,13 +138,15 @@ We encourage contributions to and feedback on all of the above and any other fil
 
 ::: {.table-responsive}
 
-| Non-standard                | Potential standard equivalents   |
-|-----------------------------|----------------------------------|
-| ethnicity                   | ethnicity_major, ethnicity_minor |
-| sex_pupils                  | sex                              |
+| Non-standard                | Potential standard equivalents     |
+|-----------------------------|------------------------------------|
+| ethnicity                   | ethnicity_major, ethnicity_minor   |
+| characteristic_sex          | sex                                |
 | school_type                 | establishment_type, establishment_type_group or education_phase |
-| pupil_sen_status            | sen_status                       |
-| characteristic_primary_need | sen_primary_need                 |
+| pupil_sen_status            | sen_status                         |
+| characteristic_primary_need | sen_primary_need                   |
+| characteristic_topic        | breakdown_topic, breakdown_topic_establishment |
+| characteristic              | breakdown, breakdown_establishment |
 
 : Example non-standard col_names and their potential equivalents in the standardised framework.
 

--- a/statistics-production/api-data-standards.qmd
+++ b/statistics-production/api-data-standards.qmd
@@ -32,11 +32,11 @@ Examples of these that do and don't meet the API data standards are provided in 
 
 The key thing on tidy data structure is to avoid filter items being included within indicator col_names. Where you have collections of related terms appearing in indicator names (e.g. male, female, total), then these should be translated into a filter column, with the data being pivoted.
 
-### Examples of bad practice
+### Example 1 - Attainment rates and scores
+
+#### Example of bad practice
 
 The following would not be accepted for publication via the API.
-
-#### Example 1 - Attainment rates and scores
 
 ::: {.table-responsive}
 
@@ -44,23 +44,13 @@ The following would not be accepted for publication via the API.
 |------------------------|------------------------|------------------------|--------------------------|--------------------------|-------------------------|----------------------|------------------------|-----------------|----------------------|------------------------|-----------------|
 | 30                     | 40                     | 50                     | 60                       | 80                       | 100                      | 0.2                  | 0.21                   | 0.21            |0.09                  | 0.08                   | 0.10            |
 
-:::
-
-#### Example 2 - Pupil counts, percents and characteristics
-
-::: {.table-responsive}
-
-| count_schools | count_pupils_male | count_pupils_female | count_pupils_total | percent_pupils_male | percent_pupils_female | percent_pupils_total |
-|---------------|-------------------|---------------------|--------------------|---------------------|-----------------------|----------------------|
-| 2             | 120               | 130                 | 250               | 48                  | 52                    | 100                  |
+: Attainment grade rates and scores in non-tidy format
 
 :::
 
-### Examples of good practice
+#### Example of good practice
 
-The following would be accepted for publication via the API. Note that in some cases, as in Example 1, splitting the data into separate data files can help with producing tidy data structures.
-
-#### Example 1a - Attainment rates
+The following would be accepted for publication via the API. In this case, splitting the data into separate data files is required in order to create tidy data structures.
 
 ::: {.table-responsive}
 
@@ -70,9 +60,11 @@ The following would be accepted for publication via the API. Note that in some c
 | Grades 9-4         | 40           | 80             |         
 | Grades 9-1         | 50           | 100            |                  
 
+: Attainment grade rates in tidy format
+
 :::
 
-#### Example 1b - Attainment scores
+::: {.table-responsive}
 
 | sex    | attainment_metric | score_average  |
 |--------|-------------------|----------------|
@@ -83,7 +75,25 @@ The following would be accepted for publication via the API. Note that in some c
 | Male   | Attainment 8      | 0.09           |         
 | Total  | Attainment 8      | 0.08           |                  
 
-#### Example 2 - Pupil counts, percents and characteristics
+: Attainment scores in tidy format
+
+:::
+
+### Example 2 - Pupil counts, percents and characteristics
+
+#### Example of bad practice
+
+::: {.table-responsive}
+
+| count_schools | count_pupils_male | count_pupils_female | count_pupils_total | percent_pupils_male | percent_pupils_female | percent_pupils_total |
+|---------------|-------------------|---------------------|--------------------|---------------------|-----------------------|----------------------|
+| 2             | 120               | 130                 | 250               | 48                  | 52                    | 100                  |
+
+: Pupil counts and percentages in non-tidy format
+
+:::
+
+#### Example of good practice
 
 ::: {.table-responsive}
 
@@ -92,6 +102,8 @@ The following would be accepted for publication via the API. Note that in some c
 | Male               | 2             | 30           | 60             |          
 | Female             | 2             | 40           | 80             |         
 | Total              | 2             | 50           | 100            |                  
+
+: Pupil counts and percentages in tidy format
 
 :::
 

--- a/statistics-production/api-data-standards.qmd
+++ b/statistics-production/api-data-standards.qmd
@@ -1,0 +1,101 @@
+---
+title: "API Data Standards"
+---
+
+```{r include=FALSE}
+```
+
+<p class="text-muted">Guidance on how to structure data files specifically for the EES API</p>
+
+---
+
+## Introduction
+
+The API offers analysts, both internal to the DfE and external consumers and communicators of education statistics,
+a way to programmatically access data on EES. However, in order to ensure a fit for purpose service, not all EES 
+data will be accessible via the API, and any that is will need to pass a higher bar for quality. In effect API data
+**must** meet all the criteria laid out in our [Open data standards guidance](../statistics-production/ud.qmd).
+
+Whilst the EES data screener tests for a significant base level of data quality and consistency, there are some 
+additional criteria that are either too awkward to test for rigorously using the screener or are tested for but
+returned as warnings. Data intended for the EES API must pass all the base level screener tests, plus a number
+that only return warnings, plus manual inspection by the platform gatekeepers. These are primarily:
+
+- Strict tidy data structures - i.e. appropriate use of filters and indicators.
+- Standardised filter col_names and items consistent with the harmonised standards.
+- Standardised indicator col_names meeting the naming standards.
+- Character limits for col_names and filter items.
+
+Examples of these that do and don't meet the API data standards are provided in the following sections.
+
+## Tidy data structure
+
+The key thing on tidy data structure is to avoid filter items being included within indicator col_names. Where you have collections of related terms appearing in indicator names (e.g. male, female, total), then these should be translated into a filter column, with the data being pivoted.
+
+### Examples of bad practice
+
+The following would not be accepted for publication via the API.
+
+#### Example 1 - Attainment rates and scores
+
+::: {.table-responsive}
+
+| count_pupils_grade9to5 | count_pupils_grade9to4 | count_pupils_grade9to1 | percent_pupils_grade9to5 | percent_pupils_grade9to4 | percent_pupils_grade9to1 | progress8_score_male | progress8_score_female | progress8_score |attainment8_score_male | attainment8_score_female | attainment8_score |
+|------------------------|------------------------|------------------------|--------------------------|--------------------------|-------------------------|----------------------|------------------------|-----------------|----------------------|------------------------|-----------------|
+| 30                     | 40                     | 50                     | 60                       | 80                       | 100                      | 0.2                  | 0.21                   | 0.21            |0.09                  | 0.08                   | 0.10            |
+
+:::
+
+#### Example 2 - Pupil counts, percents and characteristics
+
+::: {.table-responsive}
+
+| count_schools | count_pupils_male | count_pupils_female | count_pupils_total | percent_pupils_male | percent_pupils_female | percent_pupils_total |
+|---------------|-------------------|---------------------|--------------------|---------------------|-----------------------|----------------------|
+| 2             | 120               | 130                 | 250               | 48                  | 52                    | 100                  |
+
+:::
+
+### Examples of good practice
+
+The following would be accepted for publication via the API. Note that in some cases, as in Example 1, splitting the data into separate data files can help with producing tidy data structures.
+
+#### Example 1a - Attainment rates
+
+::: {.table-responsive}
+
+|attainment_metric   | count_pupils | percent_pupils |
+|--------------------|--------------|----------------|
+| Grades 9-5         | 30           | 60             |          
+| Grades 9-4         | 40           | 80             |         
+| Grades 9-1         | 50           | 100            |                  
+
+:::
+
+#### Example 1b - Attainment scores
+
+| sex    | attainment_metric | score_average  |
+|--------|-------------------|----------------|
+| Female | Progress 8        | 0.21           |          
+| Male   | Progress 8        | 0.20           |         
+| Total  | Progress 8        | 0.21           |                  
+| Female | Attainment 8      | 0.08           |          
+| Male   | Attainment 8      | 0.09           |         
+| Total  | Attainment 8      | 0.08           |                  
+
+#### Example 2 - Pupil counts, percents and characteristics
+
+::: {.table-responsive}
+
+| sex                | count_schools | count_pupils | percent_pupils |
+|--------------------|---------------|--------------|----------------|
+| Male               | 2             | 30           | 60             |          
+| Female             | 2             | 40           | 80             |         
+| Total              | 2             | 50           | 100            |                  
+
+:::
+
+###
+
+All data uploaded to EES should be in a tidy data structure form, but this is more strictly regulated for data intended for use with the API. More information on building tidy data structures can be found in the [tidy data structure section](../satistics-production/ud.html#tidy-data-structure).
+

--- a/statistics-production/api-data-standards.qmd
+++ b/statistics-production/api-data-standards.qmd
@@ -111,3 +111,24 @@ The following would be accepted for publication via the API. In this case, split
 
 All data uploaded to EES should be in a tidy data structure form, but this is more strictly regulated for data intended for use with the API. More information on building tidy data structures can be found in the [tidy data structure section](../satistics-production/ud.html#tidy-data-structure).
 
+## Standardised filter col_names and items
+
+The explore education and statistics platforms team alongside the data harmonisation champions group and publication teams are developing a series of [standardised filter-sets](../statistics-production/ud.html#common-harmonised-variables) that teams are required to adhere to when creating data for the API. These are being built iteratively as more data is put forward for the API, so if the current standards don't cater to your data set, you can contribute to building the harmonised standards for others to follow.
+
+The standards can be used to create individual filter columns or combined filters (i.e. breakdown_topic / breakdown_topic).
+
+Areas for which harmonised standards are currently available are:
+
+- [establishment / school / provider characteristics](../statistics-production/ud.html#establishment-characteristics)
+- [ethnicity](../statistics-production/ud.html#ethnicity)
+- [sex and gender](../statistics-production/ud.html#sex-and-gender)
+- [special educational needs](../statistics-production/ud.html#special-educational-needs)
+
+Areas which are currently under development are:
+
+- attainment metrics
+- disadvantaged status
+- free school meal status
+
+We encourage contributions to and feedback on all of the above and any other filter topic.
+

--- a/statistics-production/ud.qmd
+++ b/statistics-production/ud.qmd
@@ -1260,7 +1260,7 @@ knitr::include_graphics("../images/change_date_format.PNG")
 The indicators are the variables showing the measurements/statistics themselves, such as the number of pupils. These can be of different formats (e.g. text, numeric), although are numeric by default. The number of indicators will vary across publications and data files.
 
 <div class="alert alert-dismissible alert-danger">
-  <p> **Every variable in your dataset should have its own column, and each column should be a single data type**. E.g. do not create an indicator column called "pupils" that has both the number and percentage of pupils in it. Instead, create two separate columns for each measure.</p>
+  <p> **Every variable in your data set should have its own column, and each column should be a single data type**. E.g. do not create an indicator column called "pupils" that has both the number and percentage of pupils in it. Instead, create two separate columns for each measure.</p>
 </div>
 
 As an example, the number and percentage of pupil enrolments are the indicators in this dataset:


### PR DESCRIPTION
## Overview of changes

I've added a page summarising (and signposting) standards that will be a requirement (above and beyond the base EES standards) for data sets being uploaded for use with the API.

## Why are these changes being made?

We want a much more coherent data ecosystem when it comes to the API and we'll be manually checking data files against this. So we need a framework laying out clearly both for analysts intending to make data their data available via the API, and for us when reviewing a data set for acceptance on to the system.

## Detailed description of changes

I've added a specific API data standards page which is linked from the statistics production menu.

This covers four key elements:

- tidy data
- standardised filter names and items
- standardised indicator names
- character constraints on column names, labels and filter items

## Issue ticket number/s and link

## Checklist before requesting a review
- [ ] I have checked the contributing guidelines
- [ ] I have checked for and linked any relevant issues that this may resolve
- [ ] I have checked that these changes build locally
- [ ] I understand that if merged into main, these changes will be publicly available
