### PR TITLE
fix to broken EES analytics link on homepage

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -67,7 +67,7 @@ We hope it can prove a useful community driven resource for everyone from the mo
 [User engagement](statistics-production/user-eng.html)
 - Guidance on understanding and engaging with the users of published statistics
 
-[EES analytics](statistics-production/user_analytics.html)
+[EES analytics](statistics-production/user-analytics.html)
 - Understanding how users are interacting with your publications
 
 ## Writing and visualising


### PR DESCRIPTION
## Overview of changes
Somehow the EES analytics URL on the homepage has changed, used to be:
https://dfe-analytical-services.github.io/analysts-guide/statistics-production/user_analytics.html (currently gives a 404)

is now:
https://dfe-analytical-services.github.io/analysts-guide/statistics-production/user-analytics.html
