### PR TITLE
Replacing references to 'gender' with 'sex', aside from the common ha…

### DIFF
--- a/data_examples/ees_demo_datafile.csv
+++ b/data_examples/ees_demo_datafile.csv
@@ -1,4 +1,4 @@
-time_period,time_identifier,geographical_level,country_code,country_name,region_code,region_name,gender,school_phase,number_children,percent_children
+time_period,time_identifier,geographical_level,country_code,country_name,region_code,region_name,sex,school_phase,number_children,percent_children
 202021,Academic year,National,E92000001,England,,,Total,Total,1000,100.000
 202021,Academic year,National,E92000001,England,,,Male,Total,490,49.000
 202021,Academic year,National,E92000001,England,,,Female,Total,510,51.000

--- a/data_examples/ees_demo_datafile.meta.csv
+++ b/data_examples/ees_demo_datafile.meta.csv
@@ -1,5 +1,5 @@
 col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
-gender,Filter,Gender,,,,Filterbypupilgender,
+sex,Filter,Sex,,,,Filterbypupilsex,
 school_phase,Filter,Schoolphase,,,,Filterbythephaseoftheschool,
 number_children,Indicator,Numberofchildren,,,,,
 percent_children,Indicator,Percentageofchildren,,%,1,,

--- a/statistics-production/ees.qmd
+++ b/statistics-production/ees.qmd
@@ -236,7 +236,7 @@ You only have 160 characters – to make sure you are fully utilising these, hav
 
 * Is it clear how frequently the releases are published?
 
-* Is it clear what breakdowns you cover? E.g. Ethnicity, Gender, SEN?
+* Is it clear what breakdowns you cover? E.g. Ethnicity, sex, SEN?
 
 * Include the abbreviations but make sure to also write them out in full so that people can search for either, e.g. Free School Meals (FSM)
 

--- a/statistics-production/ees.qmd
+++ b/statistics-production/ees.qmd
@@ -236,7 +236,7 @@ You only have 160 characters – to make sure you are fully utilising these, hav
 
 * Is it clear how frequently the releases are published?
 
-* Is it clear what breakdowns you cover? E.g. Ethnicity, sex, SEN?
+* Is it clear what breakdowns you cover? E.g. Ethnicity, Sex, SEN?
 
 * Include the abbreviations but make sure to also write them out in full so that people can search for either, e.g. Free School Meals (FSM)
 

--- a/statistics-production/ud.qmd
+++ b/statistics-production/ud.qmd
@@ -107,7 +107,7 @@ Note that the mandatory columns time_identifier, geographic_level and country_co
 
 | col_name         | col_type  | label        | indicator_grouping | indicator_unit | indicator_dp | filter_hint | filter_grouping_column |
 |------------------|-----------|--------------|--------------------|----------------|--------------|-------------|------------------------|
-| sex          | Filter    | Gender       |                    |                |              | Filter by pupil sex |             |
+| sex          | Filter    | Sex       |                    |                |              | Filter by pupil sex |             |
 | school_phase     | Filter    | School phase |                    |                |              | Filter by the phase of the school |  |
 | children_count  | Indicator | Number of children |              |                |              |             |                        |
 | children_percent | Indicator | Percentage of children |          | %              | 1            |             |                        |

--- a/statistics-production/ud.qmd
+++ b/statistics-production/ud.qmd
@@ -519,7 +519,7 @@ Each row represents a column in the data file.
 
 | col_name | col_type | label | indicator_grouping | indicator_unit | indicator_dp | filter_hint | filter_grouping_column |
 |----------|----------|-------|--------------------|----------------|-------------|------------------------|---|
-| gender | Filter | sex | | | | Filter by pupil gender | |
+| sex | Filter | Sex | | | | Filter by pupil sex | |
 | school_phase | Filter | School phase | | | | Filter by the phase of the school | |
 | children_count | Indicator | Number of children | | | | | |
 | children_percent | Indicator | Percentage of children | | % | 1 | | |

--- a/statistics-production/ud.qmd
+++ b/statistics-production/ud.qmd
@@ -77,7 +77,7 @@ Note that the mandatory columns time_identifier, geographic_level and country_co
 
 ::: {.table-responsive}
 
-| time_period | ... | country_name | region_code | region_name | gender | school_phase | children_count  | children_percent |
+| time_period | ... | country_name | region_code | region_name | sex | school_phase | children_count  | children_percent |
 |-------------|-----|--------------|-------------|-------------|--------|--------------|-----------------|------------------|
 | 202021      | ... | England      |             |             | Total  | Total        | 1000            | 100.000          |
 | 202021      | ... | England      |             |             | Male   | Total        | 490             | 49.000           |
@@ -107,7 +107,7 @@ Note that the mandatory columns time_identifier, geographic_level and country_co
 
 | col_name         | col_type  | label        | indicator_grouping | indicator_unit | indicator_dp | filter_hint | filter_grouping_column |
 |------------------|-----------|--------------|--------------------|----------------|--------------|-------------|------------------------|
-| gender           | Filter    | Gender       |                    |                |              | Filter by pupil gender |             |
+| sex          | Filter    | Gender       |                    |                |              | Filter by pupil sex |             |
 | school_phase     | Filter    | School phase |                    |                |              | Filter by the phase of the school |  |
 | children_count  | Indicator | Number of children |              |                |              |             |                        |
 | children_percent | Indicator | Percentage of children |          | %              | 1            |             |                        |
@@ -438,7 +438,7 @@ In line with the [GSS guidance on symbols](https://gss.civilservice.gov.uk/polic
 
 | Symbol      | Usage                                         | Example                                                   | Obsolete equivalents |
 |-------------|-----------------------------------------------|-----------------------------------------------------------| -------------------- |
-| z           | When an observation is **not applicable**     | No data for at gender level for boys at an all-girls school | |
+| z           | When an observation is **not applicable**     | No data for at sex level for boys at an all-girls school | |
 | x           | When data is **unavailable** for other reasons| Data for an indicator is not collected in a certain region  | : |
 | c           | **Confidential** data | Data has been suppressed | |
 | low        | Rounds to 0, but is not 0 | Rounding to the nearest thousand, 499 would otherwise show as 0. Only use 0 for true 0's | ~ |
@@ -519,7 +519,7 @@ Each row represents a column in the data file.
 
 | col_name | col_type | label | indicator_grouping | indicator_unit | indicator_dp | filter_hint | filter_grouping_column |
 |----------|----------|-------|--------------------|----------------|-------------|------------------------|---|
-| gender | Filter | Gender | | | | Filter by pupil gender | |
+| gender | Filter | sex | | | | Filter by pupil gender | |
 | school_phase | Filter | School phase | | | | Filter by the phase of the school | |
 | children_count | Indicator | Number of children | | | | | |
 | children_percent | Indicator | Percentage of children | | % | 1 | | |

--- a/statistics-production/ud.qmd
+++ b/statistics-production/ud.qmd
@@ -438,7 +438,7 @@ In line with the [GSS guidance on symbols](https://gss.civilservice.gov.uk/polic
 
 | Symbol      | Usage                                         | Example                                                   | Obsolete equivalents |
 |-------------|-----------------------------------------------|-----------------------------------------------------------| -------------------- |
-| z           | When an observation is **not applicable**     | No data for at sex level for boys at an all-girls school | |
+| z           | When an observation is **not applicable**     | No data for boys at an all-girls school | |
 | x           | When data is **unavailable** for other reasons| Data for an indicator is not collected in a certain region  | : |
 | c           | **Confidential** data | Data has been suppressed | |
 | low        | Rounds to 0, but is not 0 | Rounding to the nearest thousand, 499 would otherwise show as 0. Only use 0 for true 0's | ~ |


### PR DESCRIPTION
…rmnised variables section.

## Overview of changes

## Why are these changes being made?
The [Example EES metadata](https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#example-ees-metadata) section on the Open Data page contains references to gender. According to the [Common Harmonised Variables section](https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#sex-and-gender), gender should not be used and should be replaced by sex instead.
## Detailed description of changes
Replacing 'gender' with sex, aside from on the [Common Harmonised Variables section](https://dfe-analytical-services.github.io/analysts-guide/statistics-production/ud.html#sex-and-gender). Have also left references to gender identity on the code of conduct section, where sex is noted separately.

## Issue ticket number/s and link
Change references to gender on Open Data page #87
## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
