### PR TITLE
Adding ADA jargon buster

### DIFF
--- a/ADA/ada.qmd
+++ b/ADA/ada.qmd
@@ -8,7 +8,7 @@
 
 ## What is the ADA project?
 
-The [Analytical Data Access (ADA) service](https://analytical-data-access.azurewebsites.net/get-support/jargon) has been created to support analysts, engineers and policy team members.
+The [Analytical Data Access (ADA) service](https://analytical-data-access.azurewebsites.net) has been created to support analysts, engineers and policy team members.
 
 It brings together:
 
@@ -22,7 +22,7 @@ It brings together:
 As long as you're connected to the network - it's available to anyone who works for the Department of Education. 
 
 ::: {.callout-tip}
-There is an Analytical Data Access [jargon buster](https://analytical-data-access.azurewebsites.net/) to help you understand different ADA and Databricks terms. 
+There is an Analytical Data Access [jargon buster](https://analytical-data-access.azurewebsites.net/get-support/jargon) to help you understand different ADA and Databricks terms. 
 :::
 
 The ADA project is currently in its onboarding phase.  The ADA team will work with analyst teams to plan migrations. We encourage teams to engage early so that you have time to migrate your work and receive support from the project team. 

--- a/ADA/ada.qmd
+++ b/ADA/ada.qmd
@@ -21,6 +21,10 @@ It brings together:
 
 As long as you're connected to the network - it's available to anyone who works for the Department of Education. 
 
+::: {.callout-tip}
+There is an Analytical Data Access [jargon buster](https://analytical-data-access.azurewebsites.net/) to help you understand different ADA and databricks terms. 
+:::
+
 The ADA project is currently in its onboarding phase.  The ADA team will work with analyst teams to plan migrations. We encourage teams to engage early so that you have time to migrate your work and receive support from the project team. 
 
 Data migration will replace three legacy systems: 

--- a/ADA/ada.qmd
+++ b/ADA/ada.qmd
@@ -8,7 +8,7 @@
 
 ## What is the ADA project?
 
-The [Analytical Data Access (ADA) service](https://analytical-data-access.azurewebsites.net/) has been created to support analysts, engineers and policy team members.
+The [Analytical Data Access (ADA) service](https://analytical-data-access.azurewebsites.net/get-support/jargon) has been created to support analysts, engineers and policy team members.
 
 It brings together:
 

--- a/ADA/ada.qmd
+++ b/ADA/ada.qmd
@@ -22,7 +22,7 @@ It brings together:
 As long as you're connected to the network - it's available to anyone who works for the Department of Education. 
 
 ::: {.callout-tip}
-There is an Analytical Data Access [jargon buster](https://analytical-data-access.azurewebsites.net/) to help you understand different ADA and databricks terms. 
+There is an Analytical Data Access [jargon buster](https://analytical-data-access.azurewebsites.net/) to help you understand different ADA and Databricks terms. 
 :::
 
 The ADA project is currently in its onboarding phase.  The ADA team will work with analyst teams to plan migrations. We encourage teams to engage early so that you have time to migrate your work and receive support from the project team. 


### PR DESCRIPTION
## Overview of changes
Adding ADA jargon buster link

## Why are these changes being made?
Linking to the 'ADA jargon buster' from the analyst guide so it's easy to find and people realise it exists. 

## Detailed description of changes
Adding to the ADA and Databricks section of Analysts Guide. Have suggested we add relatively near the top as a callout-tip box to make it easy for readers to spot. There is a section further down which gives links to ADA support - one of these already links to the page where you can also find the jargon buster, so haven't suggested we add here. 

## Issue ticket number/s and link
Add a link to the ADA 'jargon buster' #113
## Checklist before requesting a review
- [X] I have checked the contributing guidelines
- [X] I have checked for and linked any relevant issues that this may resolve
- [X] I have checked that these changes build locally
- [X] I understand that if merged into main, these changes will be publicly available
