### PR TITLE
99 tidy up git learning resources page

### DIFF
--- a/learning-development/learning-support.qmd
+++ b/learning-development/learning-support.qmd
@@ -7,7 +7,7 @@ title: "Learning support"
 ---
 
 ::: {.callout-tip}
-## Git DevOps guidance
+## Azure DevOps guidance
 You can find helpful guidance on DevOps on [Azure DevOps for Analysis](https://dfe-analytical-services.github.io/azure-devops-for-analysis/index.html). 
 :::
 

--- a/learning-development/learning-support.qmd
+++ b/learning-development/learning-support.qmd
@@ -33,9 +33,8 @@ For questions about publishing statistics, the statistics Code of Practice or ho
 
 For support in data harmonisation and data structuring standards, or support with analytical digital services including the explore education statistics service, and deploying and maintaining R Shiny applications contact the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk).
 
-For any technical questions about R, Git, SQL, RAP or statistics production, contact [statistics.development@education.gov.uk](mailto:statistics.development@education.gov.uk)  
- * This mailbox is monitored between 9-5 and we aim to reply within 2 days
- * No question is too small! We are always happy to help
+For any technical questions about R, Git, SQL, RAP or statistics production, contact [statistics.development@education.gov.uk](mailto:statistics.development@education.gov.uk). This mailbox is monitored between 9-5 and we aim to reply within 2 days. No question is too small! We are always happy to help.
+
  
  ---
 

--- a/learning-development/learning-support.qmd
+++ b/learning-development/learning-support.qmd
@@ -19,10 +19,6 @@ As analysts and statistics producers, we require a variety of tools to efficient
 
 For best practice when using software and coding in our process, see our [guidance on RAP expectations](../RAP/rap-expectations.html) and the [DfE Good Code Practice guide](https://dfe-analytical-services.github.io/good-code-practice/index.html).
 
-For questions about publishing statistics, the statistics Code of Practice or how your statistics publication should be badged, please contact the [HoP Office](mailto:hop.statistics@education.gov.uk).
-
-For support in data harmonisation and data structuring standards, or support with analytical digital services including the explore education statistics service, and deploying and maintaining R Shiny applications contact the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk).
-
 You can also access support on a variety of topics on the [cross-government Digital Slack instance](https://x-govuk.github.io/posts/how-to-use-cross-government-slack/). Some useful channels to join are `#accessibility`, `#ai`, `#data-science` and `#datavis`. 
 
 There is also a [cross-government data science Slack instance](https://govdatascience.slack.com/). Some useful channels to join are `#chat-r`, `#chat-python`, `#info-events` and `#community-rap`.
@@ -33,8 +29,12 @@ In DfE, you can also seek advice via Teams. Some useful groups are [Statistics p
 
 ## Email support
 
- * For any technical questions about R, Git, SQL, RAP or statistics production, contact [statistics.development@education.gov.uk](mailto:statistics.development@education.gov.uk)  
- * The mailbox is monitored between 9-5 and we aim to reply within 2 days
+For questions about publishing statistics, the statistics Code of Practice or how your statistics publication should be badged, please contact the [HoP Office](mailto:hop.statistics@education.gov.uk).
+
+For support in data harmonisation and data structuring standards, or support with analytical digital services including the explore education statistics service, and deploying and maintaining R Shiny applications contact the [explore education statistics platforms team](mailto:explore.statistics@education.gov.uk).
+
+For any technical questions about R, Git, SQL, RAP or statistics production, contact [statistics.development@education.gov.uk](mailto:statistics.development@education.gov.uk)  
+ * This mailbox is monitored between 9-5 and we aim to reply within 2 days
  * No question is too small! We are always happy to help
  
  ---

--- a/learning-development/learning-support.qmd
+++ b/learning-development/learning-support.qmd
@@ -6,6 +6,15 @@ title: "Learning support"
 
 ---
 
+::: {.callout-tip}
+## Git DevOps guidance
+You can find helpful guidance on DevOps on [Azure DevOps for Analysis](https://dfe-analytical-services.github.io/azure-devops-for-analysis/index.html). 
+:::
+
+---
+
+## Tools and support channels
+
 As analysts and statistics producers, we require a variety of tools to efficiently and reliably work with our data. Below are the recommended tools that give us the most power to do what we need. These have large user communities in DfE, and are already working in our current IT setup.
 
 For best practice when using software and coding in our process, see our [guidance on RAP expectations](../RAP/rap-expectations.html) and the [DfE Good Code Practice guide](https://dfe-analytical-services.github.io/good-code-practice/index.html).


### PR DESCRIPTION
## Overview of changes
Adding the link to DevOps guidance right at the top of the page in a call-out box. Suggested tidying up the page a little by adding an extra header and moving the email links from the top section to be with the SDT email address below. 

## Why are these changes being made?
So users can navigate the page a little easier and know what to find in each section, plus make it much easier for users to find the DevOps guidance

## Detailed description of changes
Added the DevOps link in a callout at the top of the page. This was originally done for us by an external user as per this PR: 
https://github.com/dfe-analytical-services/analysts-guide/pull/102. We were unable to approve this as it was forked. 

I have then also attempted to tidy up the page a little by adding an extra heading and moving the email address support to be together. I have then removed the bullets from the SDT email and added to the paragraph as they don't format nicely with the other emails there (looks odd that only that one has bullets and is hard to make it clear they are only applying to the SDT email) 

## Issue ticket number/s and link
 https://github.com/dfe-analytical-services/analysts-guide/issues/99

## Checklist before requesting a review
- [X] I have checked the contributing guidelines
- [X] I have checked for and linked any relevant issues that this may resolve
- [X] I have checked that these changes build locally
- [X] I understand that if merged into main, these changes will be publicly available
