### PR TITLE
Added guidance on dealing with chromote headless mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 /.quarto/
 *_cache/
 _site/
+site_libs/
 
 .DS_Store

--- a/learning-development/r.qmd
+++ b/learning-development/r.qmd
@@ -811,6 +811,36 @@ That command should return the path that you entered for Chrome.
 
 ---
 
+### shinytest2 - Old headless mode error message
+
+---
+
+When shinytest2 runs a Chrome or Edge browser window, it runs it in something called "headless mode", which effectively means it's running the browser in the background without you seeing the window on your desktop. The way headless mode works in Chrome and Edge recently changed, which triggers an error in shinytest2 if you haven't updated your R settings to allow for this.
+
+The resulting error should look something like the following.
+
+```
+Error in with_random_port(launch_chrome_impl, path = path, args = args) :
+Cannot find an available port. Please try again.
+Caused by error in startup():
+! Failed to start chrome. Error:
+Old Headless mode has been removed from the Chrome binary. Please use the new 
+Headless mode (https://permanently-removed.invalid/docs/chromium/new-headless) 
+or the chrome-headless-shell which is a standalone implementation of the old 
+Headless mode (https://permanently-removed.invalid/blog/chrome-headless-shell).
+```
+
+To fix this issue, you just need to let R that you want chromote sessions to run with the "new" headless mode. This can be done by setting a system variable in your .Renviron file as follows:
+
+- open your .Renviron file for editing (for example, in the R console run `usethis::edit_r_environ()`)
+- add the line `CHROMOTE_headless="new"` to the .Renviron file (and make sure the file ends in an empty line)
+- Save the .Renviron file
+- Restart your R session
+
+Now you should be able to run `shinytest2::test_app()` as normal.
+
+---
+
 ## Using R with ADA / Databricks
 
 See our [guidance on how to connect to Databricks SQL Warehouse from R Studio](../ADA/databricks_rstudio_sql_warehouse.html), and [how to connect to Databricks personal cluster from R studio](../ADA/databricks_rstudio_personal_cluster.html)

--- a/learning-development/r.qmd
+++ b/learning-development/r.qmd
@@ -830,7 +830,7 @@ or the chrome-headless-shell which is a standalone implementation of the old
 Headless mode (https://permanently-removed.invalid/blog/chrome-headless-shell).
 ```
 
-To fix this issue, you just need to let R that you want chromote sessions to run with the "new" headless mode. This can be done by setting a system variable in your .Renviron file as follows:
+To fix this issue, you just need to let R know that you want chromote sessions to run with the "new" headless mode. This can be done by setting a system variable in your .Renviron file as follows:
 
 - open your .Renviron file for editing (for example, in the R console run `usethis::edit_r_environ()`)
 - add the line `CHROMOTE_headless="new"` to the .Renviron file (and make sure the file ends in an empty line)

--- a/writing-visualising/dashboards_rshiny.qmd
+++ b/writing-visualising/dashboards_rshiny.qmd
@@ -573,7 +573,10 @@ There are a couple of potential issues that you may run into when completing mig
 
 ---
 
-Shinytest2 makes use of the Chromote package, which needs to connect to your local instance of Google Chrome. Please make sure you have Google Chrome installed before you attempt to use shinytest2, otherwise it will not work. Sometimes your copy of Chrome might be installed in a different place to where Chromote expects to find it, which means that your tests will not be able to run. There is information on how to resolve this issue [in the Tips for Using R section](../learning-development/r.html#shinytest2---invalid-path-to-chrome-error-message)
+Shinytest2 needs to connect to your local copy of either MS Edge or Google Chrome by running a chromote session. The following issues can occur when shinytest2 tries to connect to run a Chromote session:
+
+- [R can't find Edge or Chrome / invalid path to chromote](../learning-development/r.html#shinytest2---invalid-path-to-chrome-error-message)
+- [Failed to launch Chrome / Edge due to trying to run in **old headless mode**](../learning-development/r.html#shinytest2---old-headless-mode-error-message)
 
 ---
 

--- a/writing-visualising/dashboards_rshiny.qmd
+++ b/writing-visualising/dashboards_rshiny.qmd
@@ -575,7 +575,7 @@ There are a couple of potential issues that you may run into when completing mig
 
 Shinytest2 needs to connect to your local copy of either MS Edge or Google Chrome by running a chromote session. The following issues can occur when shinytest2 tries to connect to run a Chromote session:
 
-- [R can't find Edge or Chrome / invalid path to chromote](../learning-development/r.html#shinytest2---invalid-path-to-chrome-error-message)
+- [R can't find Edge or Chrome / invalid path to chromote](../learning-development/r.html#shinytest2---invalid-path-to-chrome-chromote-error-message)
 - [Failed to launch Chrome / Edge due to trying to run in **old headless mode**](../learning-development/r.html#shinytest2---old-headless-mode-error-message)
 
 ---


### PR DESCRIPTION
## Overview of changes

Recent new error on shinytest2 since Chrome and Edge removed support for the old headless mode.

## Why are these changes being made?

So people can still use shinytest2

## Detailed description of changes

- Updated R-Shiny dashboard page to more succinctly send people through to the R support materials
- Added an overview and solution to the headless mode error in the R support materials

## Issue ticket number/s and link

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
