### PR TITLE
Update prs-to-trello.yml

### DIFF
--- a/.github/workflows/prs-to-trello.yml
+++ b/.github/workflows/prs-to-trello.yml
@@ -16,5 +16,5 @@ jobs:
           list-id: '63ce5064a4859b0387f46b9b'
           title-format: 'Analysts Guide PR: ${title}'
           label-ids: |
-            '67b5ffd12ef51e02d66ad599'
-            '63ce4ffcbfa825468a8e2a69'
+            67b5ffd12ef51e02d66ad599
+            63ce4ffcbfa825468a8e2a69


### PR DESCRIPTION
## Overview of changes

The PR to Trello workflow was failing on invalid IDs. Suspect it's that the quotation marks weren't necessary, so just removing them to see if that fixes things.