### PR TITLE
removed angle brackets and replaced with "" for consistency

### DIFF
--- a/ADA/databricks_rstudio_personal_cluster.qmd
+++ b/ADA/databricks_rstudio_personal_cluster.qmd
@@ -140,9 +140,9 @@ If you have previously established a connection between a SQL Warehouse and RStu
 To set the environment variables, call `usethis::edit_r_environ()`. You will then need to enter the following information:
 
 ```         
-DATABRICKS_HOST=<databricks-host>
-DATABRICKS_CLUSTER_PATH=<databricks-cluster-path>
-DATABRICKS_TOKEN=<personal-access-token>
+DATABRICKS_HOST = "databricks-host"
+DATABRICKS_CLUSTER_PATH = "databricks-cluster-path"
+DATABRICKS_TOKEN = "personal-access-token"
 ```
 
 Once you have entered the details, save and close your .Renviron file and restart R (Session \> Restart R).

--- a/ADA/databricks_rstudio_personal_cluster_sparklyr.qmd
+++ b/ADA/databricks_rstudio_personal_cluster_sparklyr.qmd
@@ -142,9 +142,9 @@ If you have previously established a connection between a SQL Warehouse or perso
 To set the environment variables, call `usethis::edit_r_environ()`. You will then need to enter the following information:
 
 ```         
-DATABRICKS_HOST=<databricks-host>
-DATABRICKS_CLUSTER_ID=<databricks-cluster-id>
-DATABRICKS_TOKEN=<personal-access-token>
+DATABRICKS_HOST = "databricks-host"
+DATABRICKS_CLUSTER_ID = "databricks-cluster-id"
+DATABRICKS_TOKEN = "personal-access-token"
 ```
 
 Once you have entered the details, save and close your .Renviron file and restart R (Session \> Restart R).


### PR DESCRIPTION
## Overview of changes
On Databricks personal cluster pages <> were being used around values to be entered into .Renviron file, but on SQL warehouse page "" were being used. The angle brackets were confusing to some people so I have replaced them with "" for consistency. 

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
