### PR TITLE
Adding callout to Databricks host info and removing broken README link

### DIFF
--- a/ADA/databricks_rstudio_personal_cluster.qmd
+++ b/ADA/databricks_rstudio_personal_cluster.qmd
@@ -161,6 +161,10 @@ The sections below describe where to find the information needed for each of the
 
 The Databricks host is the instance of Databricks that you want to connect to. It's the URL that you see in your browser bar when you're on the Databricks site and should end in "azuredatabricks.net" (ignore anything after this section of the URL).
 
+::: callout-important
+Do not include the / at the end of the URL when you add it to the .Renviron file
+:::
+
 ------------------------------------------------------------------------
 
 #### Databricks cluster path

--- a/ADA/databricks_rstudio_personal_cluster_sparklyr.qmd
+++ b/ADA/databricks_rstudio_personal_cluster_sparklyr.qmd
@@ -163,6 +163,10 @@ The sections below describe where to find the information needed for each of the
 
 The Databricks host is the instance of Databricks that you want to connect to. It's the URL that you see in your browser bar when you're on the Databricks site and should end in "azuredatabricks.net" (ignore anything after this section of the URL).
 
+::: callout-important
+Do not include the / at the end of the URL when you add it to the .Renviron file
+:::
+
 ------------------------------------------------------------------------
 
 #### Databricks cluster id

--- a/ADA/databricks_rstudio_sql_warehouse.qmd
+++ b/ADA/databricks_rstudio_sql_warehouse.qmd
@@ -127,6 +127,10 @@ Once you have entered the details, save and close your .Renviron file and restar
 
 The Databricks host is the instance of Databricks that you want to connect to. It's the URL that you see in your browser bar when you're on the Databricks site and should end in "azuredatabricks.net" (ignore anything after this section of the URL).
 
+::: callout-important
+Do not include the / at the end of the URL when you add it to the .Renviron file
+:::
+
 ------------------------------------------------------------------------
 
 #### Databricks SQL Warehouse Path

--- a/RAP/rap-statistics.qmd
+++ b/RAP/rap-statistics.qmd
@@ -1048,7 +1048,7 @@ It's an easy way to answer questions that your audience will likely have regardi
 
 **How to get started**
 
-For new projects, you can use the create_project function in dfeR. Set create_publication_proj to TRUE to create a pre-populated project with a custom folder structure, including a [README template](https://github.com/dfe-analytical-services/dfeR/blob/main/README_template.md).  You can find more information on this in the [dfeR reference](https://dfe-analytical-services.github.io/dfeR/reference/create_project.html).
+For new projects, you can use the create_project function in dfeR. Set create_publication_proj to TRUE to create a pre-populated project with a custom folder structure, including a README template. You can find more information on this in the [dfeR reference](https://dfe-analytical-services.github.io/dfeR/reference/create_project.html).
 
 If you are creating your own README for existing projects, you should include all of the sections listed below:
 


### PR DESCRIPTION
## Overview of changes
- Nick requested that we add a callout to the Databricks Host sections to remind people not to include the / as it breaks things and he's seen quite a few people run into that issue
- There was a broken README link on the RAP page, I've removed it because the README is now embedded in code rather than being a standalone .md file that we can link to

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
