### PR TITLE
Fixing personal cluster instructions

### DIFF
--- a/ADA/databricks_rstudio_personal_cluster.qmd
+++ b/ADA/databricks_rstudio_personal_cluster.qmd
@@ -179,7 +179,7 @@ In Databricks, go to Compute in the left hand menu, and click on the name of you
 ![](../images/databricks-cluster-path.png)
 :::
 
-On the Configuration tab, scroll to the bottom of the page and click Advanced Options \> JDBC/ODBC \> HTTP Path, and copy the text after the last forward slash. This is your cluster path.
+On the Configuration tab, scroll to the bottom of the page and click Advanced Options \> JDBC/ODBC \> HTTP Path, and copy the text in the box. This is your cluster path.
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
## Overview of changes
Updated guidance on how to find Databricks Cluster Path for .Renviron file to allow users to connect personal cluster to RStudio 

## Why are these changes being made?
Current instructions are wrong

## Issue ticket number/s and link
Should address issue #157 

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
