### PR TITLE
add gallery of R charts link to 'other resources' section in R

### DIFF
--- a/learning-development/r.qmd
+++ b/learning-development/r.qmd
@@ -190,6 +190,8 @@ This is surprisingly neat to do. Let's say you wanted to roll back to version 1.
 
 - Malcolm Barrett has done some slides on [dplyr](https://malco.io/slides/hs_dplyr/#1){target="_blank" rel="noopener noreferrer"}, [ggplot2](https://malco.io/slides/hs_ggplot2/#1){target="_blank" rel="noopener noreferrer"}, and using [purrr](https://lar-purrr.netlify.app/#1){target="_blank" rel="noopener noreferrer"} which may be useful if you're looking at learning more about any of those packages.
 
+- Check out the [gallery of R charts](https://www.r-graph-gallery.com/){target="_blank" rel="noopener noreferrer"} for some visualisation inspiration - this website has over 400 examples grouped into 50 different chart types!
+
 - Also check out the [janitor](https://garthtarr.github.io/meatR/janitor.html){target="_blank" rel="noopener noreferrer"} package, it has some particularly powerful functions that are worth a look for tidying and QA'ing data.
 
 ---


### PR DESCRIPTION
## Overview of changes
issue #76 - add the helpful link to https://r-graph-gallery.com/ to the R learning resources page

## Why are these changes being made?
To signpost to a useful external resource :)

## Detailed description of changes
Just one additional bullet point added to the existing 'other resources' list.

## Issue ticket number/s and link
#76 

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
