### PR TITLE
Fixing broken Databricks link 

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -121,7 +121,7 @@ We hope it can prove a useful community driven resource for everyone from the mo
 [Personal cluster with RStudio and `sparklyr`](ADA/databricks_rstudio_personal_cluster_sparklyr.html)
 - Guidance for analysts on how to connect to a Databricks personal cluster from RStudio using sparklyr
 
-[Use Databricks with Git](ADA/databricks_git.html)
+[Use Databricks with Git](ADA/git_databricks.html)
 - Guidance for connecting Databricks to Git repositories
 
 [Script workflows in Databricks](ADA/databricks_workflow_script_databricks.html)


### PR DESCRIPTION
## Overview of changes
Link to using Databricks with Git page on Analysts Guide homepage was broken

## Issue ticket number/s and link
Should resolve issue #166 

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
