### PR TITLE
Added info on missing config file when using Databricks on AVD

### DIFF
--- a/ADA/databricks_rstudio_personal_cluster_sparklyr.qmd
+++ b/ADA/databricks_rstudio_personal_cluster_sparklyr.qmd
@@ -386,6 +386,16 @@ To resolve this restart your R session (Session \> Restart R) then re-run the `s
 
 ------------------------------------------------------------------------
 
+#### Queries hang when connecting to Databricks from RStudio on Azure Virtual Desktop
+
+------------------------------------------------------------------------
+
+If your query runs for a long time and doesn't return any results, check that you have a config.yml file. 
+
+The `spark_connect()` function requires this config file to run correctly. If you don't have a config.yml file, create a blank one in your project folder, and your queries should then run correctly. 
+
+------------------------------------------------------------------------
+
 #### I'm having another problem with virtual environments
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
## Overview of changes
A user raised the following issue when trying to connect to Databricks from RStudio using a personal cluster on Azure Virtual Desktop: 

All the connection setup steps in the guidance worked, but when trying to run the spark_connect() function, the code just runs and runs for a long time and doesn't return anything at all.

Upon investigation, it was because they were missing a config.yml file. Adding a blank one fixes the problem. I've added this to the troubleshooting section on the Personal cluster with RStudio and `sparklyr` page

## Why are these changes being made?
To help other uses who encounter the same issue

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
