### PR TITLE
fix 'recyclable code for future use' link in r.qmd

### DIFF
--- a/learning-development/r.qmd
+++ b/learning-development/r.qmd
@@ -79,7 +79,7 @@ You should use the [renv package](https://rstudio.github.io/renv/articles/renv.h
 
 Packages and versions of R regularly update. Over time, this can cause code to break - e.g. if different dependencies are required for later versions of packages to work. Using renv creates a "snapshot" of your code and packages at the time you created it, which anyone can then recreate when they come to use your code. 
 
-This is really important for reproducibility, and will help you meet elements of great practice with [recyclable code for future use](../RAP/rap.html#recyclable-code-for-future-use).
+This is really important for reproducibility, and will help you meet elements of great practice with [recyclable code for future use](../RAP/rap-start-guide.html#recyclable-code-for-future-use).
 
 ---
 


### PR DESCRIPTION
## Overview of changes
Update link in renv section of r.qmd script to point to correct location

## Why are these changes being made?
Previous link was broken

## Detailed description of changes
Update rap.html to rap-start-guide.html

## Issue ticket number/s and link
#174 

## Checklist before requesting a review
- [✅] I have checked the contributing guidelines
- [✅] I have checked for and linked any relevant issues that this may resolve
- [✅] I have checked that these changes build locally
- [✅] I understand that if merged into main, these changes will be publicly available
