### PR TITLE
Updating broken link to SQL style guide

### DIFF
--- a/learning-development/sql.qmd
+++ b/learning-development/sql.qmd
@@ -51,7 +51,7 @@ Here are some tips to follow best practice in your SQL code, making it easier to
 * Try to only comment on things that aren't obvious about the query (e.g. why hardcoded filters are used, how to update them)
 * Where possible, use [Common Table Expressions (CTEs)](https://www.essentialsql.com/introduction-common-table-expressions-ctes/){target="_blank" rel="noopener noreferrer"} early and often, and name them descriptively (e.g. "pupil_age_table" rather than "p")
 
-[GitLab](https://about.gitlab.com/) have produced a full [SQL style guide](https://about.gitlab.com/handbook/business-technology/data-team/platform/sql-style-guide/), which we recommend following where possible.
+[GitLab](https://about.gitlab.com/) have produced a full [SQL style guide](https://handbook.gitlab.com/handbook/enterprise-data/platform/sql-style-guide/), which we recommend following where possible.
 
 ---
 


### PR DESCRIPTION
## Overview of changes
Updating broken link 
## Why are these changes being made?
The current link takes you to a 404 page not found error. This may be frustrating to users, who then may give up looking for the link and not find information on SQL best practice 
## Detailed description of changes
Updating the SQL style guide link to the new and working link 
## Issue ticket number/s and link
#165 
## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
