### PR TITLE
Updating broken link for SQL warehouse section

### DIFF
--- a/ADA/databricks_rstudio_sql_warehouse.qmd
+++ b/ADA/databricks_rstudio_sql_warehouse.qmd
@@ -137,7 +137,7 @@ Do not include the / at the end of the URL when you add it to the .Renviron file
 
 ------------------------------------------------------------------------
 
-As described in the [SQL Warehouses section](/ADA/ada.html#sql-warehouse), in Databricks, SQL Warehouses are a way to gain access to your data in the Unity Catalog. They run queries and return the results either to the user or to a table. 
+As described in the [SQL Warehouses section](#sql-warehouse), in Databricks, SQL Warehouses are a way to gain access to your data in the Unity Catalog. They run queries and return the results either to the user or to a table. 
 
 To get the Warehouse ID, follow these steps:
 


### PR DESCRIPTION
## Overview of changes
Changing link address as currently just goes to general ADA page

## Why are these changes being made?
The link references the SQL Warehouse section but it currently takes you the ADA main page, where SQL Warehouses are not mentioned. 

## Detailed description of changes
Link changed to point back up the same page to where SQL Warehouse is discussed. 

## Issue ticket number/s and link
#175 
## Checklist before requesting a review
- [X] I have checked the contributing guidelines
- [X] I have checked for and linked any relevant issues that this may resolve
- [X] I have checked that these changes build locally
- [X] I understand that if merged into main, these changes will be publicly available
