### PR TITLE
Fixing SQL video links

### DIFF
--- a/learning-development/git.qmd
+++ b/learning-development/git.qmd
@@ -45,7 +45,7 @@ When you first try to use Git you may be prompted for a GitHub username and pass
 
 ## Best places to start
 
-- Work through [DfE Git Academy](https://dfe-analytical-services.github.io/git-academy/https://dfe-analytical-services.github.io/git-academy). This is a collection of interactive tasks which you can use to learn and practice using Git. See the [prerequisites section](https://dfe-analytical-services.github.io/git-academy/prerequisites.html) for information on how to get started. 
+- Work through [DfE Git Academy](https://dfe-analytical-services.github.io/git-academy/). This is a collection of interactive tasks which you can use to learn and practice using Git. See the [prerequisites section](https://dfe-analytical-services.github.io/git-academy/prerequisites.html) for information on how to get started. 
 
 - [Contact us](mailto:statistics.development@education.gov.uk) about attending one of our in-person Git workshops.
 

--- a/learning-development/sql.qmd
+++ b/learning-development/sql.qmd
@@ -35,7 +35,7 @@ If you can't find the option in the software centre, then you may need to raise 
 Andy Brook's excellent Introduction to SQL session, giving a visual overview of the basics of querying with SQL:
 
 <div align="center">
-<iframe width="640" height="360" align="middle" src="https://web.microsoftstream.com/embed/video/2a42789f-5183-4a79-b159-ec4a46e530d7?autoplay=false&amp;showinfo=false" allowfullscreen style="border:none;"></iframe>
+<iframe src="https://educationgovuk.sharepoint.com/sites/itops/_layouts/15/embed.aspx?UniqueId=09204bd9-ecee-5999-6b77-d9b7921c264a&embed=%7B%22ust%22%3Atrue%2C%22hv%22%3A%22CopyEmbedCode%22%7D&referrer=StreamWebApp&referrerScenario=EmbedDialog.Create" width="640" height="360" frameborder="0" scrolling="no" allowfullscreen title="SQL Introduction Bitesize-20200409_125431-Meeting Recording.mp4"></iframe>
 </div>
 
 ---
@@ -86,7 +86,7 @@ Once you have saved SQL scripts or are more familiar with writing SQL queries on
 Andy's follow up intermediate SQL session, covering more advanced features of SQL:
 
 <div align="center">
-<iframe width="640" height="360" align="middle" src="https://web.microsoftstream.com/embed/video/0b96598e-1d4c-4c5e-807a-4efc264bc1cc?autoplay=false&amp;showinfo=false" allowfullscreen style="border:none;"></iframe>
+<iframe src="https://educationgovuk.sharepoint.com/sites/itops/_layouts/15/embed.aspx?UniqueId=ecbbe8e9-339a-544b-00aa-00f24759be11&embed=%7B%22ust%22%3Atrue%2C%22hv%22%3A%22CopyEmbedCode%22%7D&referrer=StreamWebApp&referrerScenario=EmbedDialog.Create" width="640" height="360" frameborder="0" scrolling="no" allowfullscreen title="SQL Intermediate Bitesize-20200820_123955-Meeting Recording.mp4"></iframe>
 </div>
 
 


### PR DESCRIPTION
## Overview of changes
Amending links to SQL introduction and intermediate videos and editing broken link to Git Academy

## Why are these changes being made?
The previous links were broken, with the error message 'this video cannot be loaded'. Git Academy link was pasted twice so was not working. 

## Detailed description of changes
Amending the SQL links to the updated version. The link now requests that internal users log in before being able to view the video.  Removing the duplication on the Git Academy link so it works. 

## Checklist before requesting a review
- [X] I have checked the contributing guidelines
- [X] I have checked for and linked any relevant issues that this may resolve
- [X] I have checked that these changes build locally
- [X] I understand that if merged into main, these changes will be publicly available
