### PR TITLE
Add k to data symbols table

### DIFF
--- a/statistics-production/ud.qmd
+++ b/statistics-production/ud.qmd
@@ -444,9 +444,11 @@ In line with the [GSS guidance on symbols](https://gss.civilservice.gov.uk/polic
 | low / k     | Rounds to 0, but is not 0 | Rounding to the nearest thousand, 499 would otherwise show as 0. Only use 0 for true 0's | ~ |
 | u       | When an observation is of *low reliability* | Data for a local authority is identified as missing returns so is removed from regional and national totals | |
 
+::: {.callout-note}
+Use of the word low may be problematic for sensitive data such as data on deaths. If this is the case you should instead use k to represent a low figure that appears as a zero when rounded. Where this is not the case however, low is preferred as it is clearer for users.
+:::
 
-If you have any other conventions you've used in previous publications, or a scenario that isn't covered above, check the [GSS guidance](https://gss.civilservice.gov.uk/policy-store/symbols-in-tables-definitions-and-help/){target="_blank" rel="noopener noreferrer"} (ignoring the part around separate columns for symbols), and contact us.
-
+If you have any other conventions you've used in previous publications, a scenario that isn't covered above or want more details on when and where to use the symbols, check the [GSS guidance](https://gss.civilservice.gov.uk/policy-store/symbols-in-tables-definitions-and-help/){target="_blank" rel="noopener noreferrer"} (ignoring the part around separate columns for symbols), and contact us.
 
 ---
 


### PR DESCRIPTION
## Overview of changes

Adding k to the options in the data symbols table

## Why are these changes being made?

To bring it in line with what we added to EES
![image](https://github.com/user-attachments/assets/3540a119-ea31-49b0-bf97-8b6e4a5b1208)

## Detailed description of changes

k is the alternative I devised with the GSS central team for instances where we're talking about sensitive areas such as death, where 'low' is not appropriate as a term.

## Issue ticket number/s and link

No related ticket

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [ ] I have checked for and linked any relevant issues that this may resolve
- [ ] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
