### PR TITLE
Add renv troubleshooting tip

### DIFF
--- a/learning-development/r.qmd
+++ b/learning-development/r.qmd
@@ -755,7 +755,7 @@ renv::record("package")
 renv::restore()
 ```
 
-However, sometimes you have so many packages this becomes tedious. In these instances you can do the nuclear option of updating all packages to their latest versions by using `renv::init()` and then selecting to discard the old lockfile and re-initialising the project.
+However, sometimes you have so many packages this becomes tedious. In these instances you can do the nuclear option of updating all packages to their latest versions by using `renv::init()` and then selecting to discard the old lockfile and re-initialising the project from the options you'll be prompted with in the console.
 
 ---
 

--- a/learning-development/r.qmd
+++ b/learning-development/r.qmd
@@ -741,6 +741,24 @@ mutated <- mutate(mtcars, new_var = wt ** 2)
 
 ## Troubleshooting
 
+### Can't restore from lockfile
+
+---
+
+Sometimes when reviving an old branch of a `renv` controlled project, you may find a number of older versions of R packages fail to restore (e.g. Matrix, terra). Normally if it's just one or two, you can do the following to manually update them:
+
+```
+renv::install("package")
+renv::record("package")
+
+# Then you can try restoring again
+renv::restore()
+```
+
+However, sometimes you have so many packages this becomes tedious. In these instances you can do the nuclear option of updating all packages to their latest versions by using `renv::init()` and then selecting to discard the old lockfile and re-initialising the project.
+
+---
+
 ### Can't find make error
 
 ---


### PR DESCRIPTION
## Overview of changes

Quick troubleshooting note for issues when using `renv::restore()`.

## Why are these changes being made?

I was having some pain restoring a new clone of the shiny-template repo on a branch and then found that I could just `renv::init()` to reset all packages to their latest version (which is usually the fix I do in this instances).

## Detailed description of changes

Added a note on the `renv::init()` option, but also notes on how to deal with individual difficult packages.

## Issue ticket number/s and link

No related issue.

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [ ] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
