### PR TITLE
issue #199 Updating broken links

### DIFF
--- a/statistics-production/embedded-charts.qmd
+++ b/statistics-production/embedded-charts.qmd
@@ -106,10 +106,10 @@ We are currently developing a route to allow charts via R Shiny apps to be hoste
 
 Many of the same principles that apply to creating a full R Shiny dashboard apply to creating a custom embeddable charts. These are:
 
-   * [Accessibility](dashboards.html#accessibility-testing);
-   * [Reliability](dashboards.html#testing-r-shiny);
-   * [Performance](dashboards.html#performance-testing);
-   * [Coherent styling](dashboards.html#styling).
+   * [Accessibility](../writing-visualising/dashboards.html#accessibility);
+   * [Reliability](../writing-visualising/dashboards.html#code-testing);
+   * [Performance](../writing-visualising/dashboards.html#governance);
+   * [Coherent styling](../writing-visualising/dashboards.html#standards-to-follow).
 
 ---
 

--- a/statistics-production/embedded-charts.qmd
+++ b/statistics-production/embedded-charts.qmd
@@ -108,8 +108,8 @@ Many of the same principles that apply to creating a full R Shiny dashboard appl
 
    * [Accessibility](../writing-visualising/dashboards.html#accessibility);
    * [Reliability](../writing-visualising/dashboards.html#code-testing);
-   * [Performance](../writing-visualising/dashboards.html#governance);
-   * [Coherent styling](../writing-visualising/dashboards.html#standards-to-follow).
+   * [Performance](../writing-visualising/dashboards_rshiny.html#dashboard-performance);
+   * [Coherent styling](../writing-visualising/dashboards_rshiny.html#dfe-styling-and-the-dfe-r-shiny-template).
 
 ---
 


### PR DESCRIPTION
## Overview of changes

- Correct the relative paths and anchor names for all four links under **Development requirements** in statistics-production/embedded-charts.qmd

## Why are these changes being made?

- The existing links (dashboards.html#accessibility-testing, etc) point to the wrong folder and use anchors that don’t exist, resulting in 404 errors when the site is published

## Detailed description of changes

- **File**: statistics-production/embedded-charts.qmd

- **Before**:
```markdown
* [Accessibility](dashboards.html#accessibility-testing);
* [Reliability](dashboards.html#testing-r-shiny);
* [Performance](dashboards.html#performance-testing);
* [Coherent styling](dashboards.html#styling).
```
- **After**:
```markdown
* [Accessibility](../writing-visualising/dashboards.html#accessibility);
* [Reliability](../writing-visualising/dashboards.html#code-testing);
* [Performance](../writing-visualising/dashboards.html#governance);
* [Coherent styling](../writing-visualising/dashboards.html#standards-to-follow).
```

- **To note**: I was only able to find performance mentioned under governance.
- Ran quarto render && quarto check locally—no broken links remain.

## Issue ticket number/s and link

- Resolve #199

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
