### PR TITLE
Amending sparklyr guidance as previous guidance no longer works

### DIFF
--- a/ADA/databricks_rstudio_personal_cluster_sparklyr.qmd
+++ b/ADA/databricks_rstudio_personal_cluster_sparklyr.qmd
@@ -225,7 +225,7 @@ It is very important that you immediately copy the access token that you are giv
 Sparklyr can be inconsistent with connection methods and code changing regularly. If you are looking for a more stable connection, consider using [Personal cluster with RStudio and `odbc` / `DBI page](ADA/databricks_rstudio_personal_cluster.html).
 :::
 
-After setting up your Host and Token in your .Renviron file, you can connect to your cluster by providing the Cluster's ID and the method to `spark_connect()`.
+After setting up your [Host and Token](ADA/databricks_rstudio_personal_cluster_sparklyr.html#establishing-an-rstudio-connection-using-environment-variables) in your .Renviron file, you can connect to your cluster by providing the Cluster's ID and the method to `spark_connect()`.
 
 ``` r
 install.packages("sparklyr")


### PR DESCRIPTION
## Overview of changes
Amending sparklyr guidance to use spark_connect 
## Why are these changes being made?
The previous method using reticulate no longer works. 

## Detailed description of changes
- Updating method to use spark_connect 
- Adding information of how to delete reticulate if users had previously used this method 
- Adding warning box that sparklyr can be inconsistent 

## Issue ticket number/s and link
#212 

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
