### PR TITLE
New page - Datacamp tracks

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -83,6 +83,7 @@ website:
           - learning-development/r.qmd
           - learning-development/git.qmd
           - learning-development/python.qmd
+          - learning-development/datacamp-tracks.qmd
           - ADA/ada.qmd
           - ADA/databricks_fundamentals.qmd
           - ADA/databricks_notebooks.qmd

--- a/index.qmd
+++ b/index.qmd
@@ -35,6 +35,9 @@ We hope it can prove a useful community driven resource for everyone from the mo
 [Python](learning-development/python.html)
 - Guidance and tips for using Python
 
+[Datacamp learning tracks for analysts](learning-development/datacamp-tracks.html)
+- Recommended Datacamp learning tracks for analysts 
+
 [Analytical Data Access (ADA)](ADA/ada.html)
 - Information on the ADA project and guidance for analysts on how to interact with and use data stored in ADA using Databricks
 

--- a/index.qmd
+++ b/index.qmd
@@ -35,7 +35,7 @@ We hope it can prove a useful community driven resource for everyone from the mo
 [Python](learning-development/python.html)
 - Guidance and tips for using Python
 
-[Datacamp learning tracks for analysts](learning-development/datacamp-tracks.html)
+[DataCamp learning tracks](learning-development/datacamp-tracks.html)
 - Recommended Datacamp learning tracks for analysts 
 
 [Analytical Data Access (ADA)](ADA/ada.html)

--- a/index.qmd
+++ b/index.qmd
@@ -36,7 +36,7 @@ We hope it can prove a useful community driven resource for everyone from the mo
 - Guidance and tips for using Python
 
 [DataCamp learning tracks](learning-development/datacamp-tracks.html)
-- Recommended Datacamp learning tracks for analysts 
+- Recommended DataCamp learning tracks for analysts 
 
 [Analytical Data Access (ADA)](ADA/ada.html)
 - Information on the ADA project and guidance for analysts on how to interact with and use data stored in ADA using Databricks

--- a/learning-development/datacamp-tracks.qmd
+++ b/learning-development/datacamp-tracks.qmd
@@ -25,7 +25,7 @@ Learning tracks are sets of courses put together using DataCamp to help you buil
 
 Each track is tailored to different levels of technical skills and experience, helping you decide which track would be best for you. You'll find estimated duration per course and per track to help you plan your time, and a special AI for All track to get everyone up to speed on foundational AI concepts. Use this page to identify the track that best fits your current goals and needs and head over to [DataCamp](https://www.datacamp.com/) to start learning!
 
-## Summary of Learning Tracks
+## Summary of learning tracks
 
 | Track Name | Target Persona | Estimated Duration |
 |-------------------|------------------------|-----------------------------|
@@ -37,11 +37,11 @@ Each track is tailored to different levels of technical skills and experience, h
 | Experienced – High Technical Skill | Experienced member, high technical skill | \~20 hours |
 | One Big Thing – AI for All: A Headstart! | All staff, introductory AI awareness | \~6–8 hours |
 
-## DataCamp Learning Tracks for Analysts
+## DataCamp learning tracks for analysts
 
-### Track 1: New to Role – Intro Level
+### Track 1: new to role – intro level
 
-**Estimated Total Duration**: \~13 hours
+**Estimated total duration**: \~13 hours
 
 | Course | UKSA/GSG Competency | Description | Duration | Link |
 |---------------|---------------|---------------|---------------|---------------|
@@ -52,9 +52,9 @@ Each track is tailored to different levels of technical skills and experience, h
 | Communicating Data Insights | Data communication | Learn how to present findings clearly to stakeholders. | 2h | [Link](https://www.datacamp.com/courses/communicating-data-insights) |
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
-### Track 2: New to Role – Intermediate Level
+### Track 2: new to role – intermediate level
 
-**Estimated Total Duration**: \~14 hours
+**Estimated total duration**: \~14 hours
 
 | Course | UKSA/GSG Competency | Description | Duration | Link |
 |---------------|---------------|---------------|---------------|---------------|
@@ -64,9 +64,9 @@ Each track is tailored to different levels of technical skills and experience, h
 | Introduction to Git | Reproducibility | Learn version control basics to track and share code. | 2h | [Link](https://www.datacamp.com/courses/introduction-to-git) |
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
-### Track 3: New to Role – High Technical Skill
+### Track 3: new to role – high technical skill
 
-**Estimated Total Duration**: \~15 hours
+**Estimated total duration**: \~15 hours
 
 | Course | UKSA/GSG Competency | Description | Duration | Link |
 |---------------|---------------|---------------|---------------|---------------|
@@ -77,9 +77,9 @@ Each track is tailored to different levels of technical skills and experience, h
 | Advanced SQL | Complex querying | Learn subqueries, window functions, and performance tuning. | 3h | [Link](https://www.datacamp.com/courses/advanced-sql) |
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
-### Track 4: Experienced – Low Technical Skill
+### Track 4: experienced – low technical skill
 
-**Estimated Total Duration**: \~16 hours
+**Estimated total duration**: \~16 hours
 
 | Course | UKSA/GSG Competency | Description | Duration | Link |
 |---------------|---------------|---------------|---------------|---------------|
@@ -91,9 +91,9 @@ Each track is tailored to different levels of technical skills and experience, h
 | Introduction to SQL | Data acquisition | Learn to query databases using SELECT, WHERE, and JOIN. | 2h | [Link](https://www.datacamp.com/courses/introduction-to-sql) |
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
-### Track 5: Experienced – Intermediate Technical Skill
+### Track 5: experienced – intermediate technical skill
 
-**Estimated Total Duration**: \~18 hours
+**Estimated total duration**: \~18 hours
 
 | Course | UKSA/GSG Competency | Description | Duration | Link |
 |---------------|---------------|---------------|---------------|---------------|
@@ -105,9 +105,9 @@ Each track is tailored to different levels of technical skills and experience, h
 | SQL for Data Analysis | Analytical querying | Learn to extract insights from databases. | 3h | [Link](https://www.datacamp.com/courses/sql-for-data-analysis) |
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
-### Track 6: Experienced – High Technical Skill
+### Track 6: experienced – high technical skill
 
-**Estimated Total Duration**: \~20 hours
+**Estimated total duration**: \~20 hours
 
 | Course | UKSA/GSG Competency | Description | Duration | Link |
 |---------------|---------------|---------------|---------------|---------------|
@@ -120,9 +120,9 @@ Each track is tailored to different levels of technical skills and experience, h
 | Building Dashboards in Power BI | Visual storytelling | Learn to create interactive dashboards. | 2h | [Link](https://www.datacamp.com/courses/building-dashboards-in-power-bi) |
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
-### Track 7: One Big Thing – AI for All: A Headstart!
+### Track 7: One Big Thing – AI for all: a headstart!
 
-**Estimated Total Duration**: \~6–8 hours
+**Estimated total duration**: \~6–8 hours
 
 | Course | Description | Duration | Link |
 |-----------------|--------------------|-----------------|-----------------|

--- a/learning-development/datacamp-tracks.qmd
+++ b/learning-development/datacamp-tracks.qmd
@@ -39,7 +39,7 @@ You'll find estimated duration per course and per track to help you plan your ti
 | New to Role – High Technical Skill | New to role, high technical skill | \~15 hours |
 | Experienced – Low Technical Skill | Experienced member, low technical skill | \~16 hours |
 | Experienced – Intermediate Technical Skill | Experienced member, intermediate technical skill | \~18 hours |
-| Experienced – High Technical Skill | Experienced member, high technical skill | \~20 hours |
+| Experienced – High Technical Skill | Experienced member, high technical skill | \~20-22 hours |
 
 ## DataCamp learning tracks
 

--- a/learning-development/datacamp-tracks.qmd
+++ b/learning-development/datacamp-tracks.qmd
@@ -95,7 +95,7 @@ Each track is tailored to different levels of technical skills and experience, h
 
 **Estimated total duration**: \~18 hours
 
-| Course | UKSA/GSG Competency | Description | Duration | Link |
+| Course | UKSA / GSG Competency | Description | Duration | Link |
 |---------------|---------------|---------------|---------------|---------------|
 | Intermediate Python OR R | Programming logic | Learn loops, conditionals, and functions. | 4h | [Python](https://www.datacamp.com/courses/intermediate-python), [R](https://www.datacamp.com/courses/intermediate-r) |
 | Exploratory Data Analysis in Python OR R | Data exploration | Learn how to summarize, visualize, and interpret data. | 3h | [Python](https://www.datacamp.com/courses/exploratory-data-analysis-in-python), [R](https://www.datacamp.com/courses/exploratory-data-analysis-in-r) |

--- a/learning-development/datacamp-tracks.qmd
+++ b/learning-development/datacamp-tracks.qmd
@@ -134,7 +134,7 @@ You'll find estimated duration per course and per track to help you plan your ti
 | Data Engineering for Everyone | Data pipelines | Understand ETL workflows and data infrastructure. | 2h | [Link](https://www.datacamp.com/courses/data-engineering-for-everyone) |
 | Git and Version Control | Reproducibility | Learn branching, merging, and collaboration. | 2h | [Link](https://www.datacamp.com/courses/git-and-version-control) |
 | Data Ethics and Privacy | Responsible data use | Explore privacy, consent, and ethical frameworks. | 2h | [Link](https://www.datacamp.com/courses/data-ethics-and-privacy) |
-| Building Dashboards in Power BI OR R Shiny OR Python| Visual storytelling | Learn to create interactive dashboards. | 2h | [Power BI](https://www.datacamp.com/courses/building-dashboards-in-power-bi), [R Shiny](https://app.datacamp.com/learn/courses/building-web-applications-with-shiny-in-r), [Python](https://app.datacamp.com/learn/courses/building-dashboards-with-dash-and-plotly)|
+| Building Dashboards in Power BI OR R Shiny OR Python| Visual storytelling | Learn to create interactive dashboards. | 2-4h | [Power BI](https://www.datacamp.com/courses/building-dashboards-in-power-bi), [R Shiny](https://app.datacamp.com/learn/courses/building-web-applications-with-shiny-in-r), [Python](https://app.datacamp.com/learn/courses/building-dashboards-with-dash-and-plotly)|
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
 

--- a/learning-development/datacamp-tracks.qmd
+++ b/learning-development/datacamp-tracks.qmd
@@ -9,7 +9,7 @@ format: html
 
 This page contains a tailored set of learning paths designed to support your development as an analyst in the Department for Education (DfE). These tracks draw on DataCamp's extensive course offerings to build competencies aligned with the Government Statistical Service (GSG) framework.
 
-Each track is tailored to different levels of technical skills and experience, helping you decide which track would be best for you. You'll find estimated duration to help you plan your time, and a special AI for All track to get everyone up to speed on foundational AI concepts. Use this page to identify the track that best fits your current goals and needs and head over to [Datacamp](https://www.datacamp.com/) to start learning!
+Each track is tailored to different levels of technical skills and experience, helping you decide which track would be best for you. You'll find estimated duration per course and per track to help you plan your time, and a special AI for All track to get everyone up to speed on foundational AI concepts. Use this page to identify the track that best fits your current goals and needs and head over to [Datacamp](https://www.datacamp.com/) to start learning!
 
 ---
 

--- a/learning-development/datacamp-tracks.qmd
+++ b/learning-development/datacamp-tracks.qmd
@@ -1,0 +1,122 @@
+---
+title: "Datacamp learning tracks"
+format: html
+---
+
+<p class="text-muted">  Learning tracks for analysts looking to upskill using Datacamp </p>
+
+---
+
+This page contains a tailored set of learning paths designed to support your development as an analyst in the Department for Education (DfE). These tracks draw on DataCamp's extensive course offerings to build competencies aligned with the Government Statistical Service (GSG) framework.
+
+Each track is tailored to different levels of technical skills and career stage, helping you decide which track would be best for you. You'll find estimated duration to help you plan your time, and a special AI for All track to get everyone up to speed on foundational AI concepts. Use this page to identify the track that best fits your current goals and needs and head over to [Datacamp](https://www.datacamp.com/) to start learning!
+
+---
+
+# Summary of Learning Tracks
+
+| Track Name | Target Persona | Estimated Duration |
+|-------------------|------------------------|-----------------------------|
+| New to Role – Intro Level | New to role, low technical skill | \~13 hours |
+| New to Role – Intermediate Level | New to role, intermediate technical skill | \~14 hours |
+| New to Role – High Technical Skill | New to role, high technical skill | \~15 hours |
+| Experienced – Low Technical Skill | Experienced member, low technical skill | \~16 hours |
+| Experienced – Intermediate Technical Skill | Experienced member, intermediate technical skill | \~18 hours |
+| Experienced – High Technical Skill | Experienced member, high technical skill | \~20 hours |
+| One Big Thing – AI for All: A Headstart! | All staff, introductory AI awareness | \~6–8 hours |
+
+# DataCamp Learning Tracks for Analysts
+
+## Track 1: New to Role – Intro Level
+
+**Estimated Total Duration**: \~13 hours
+
+| Course | UKSA/GSG Competency | Description | Duration | Link |
+|---------------|---------------|---------------|---------------|---------------|
+| Introduction to Python OR R | Programming fundamentals | Learn Python or R basics, variables, lists, functions, and data structures for analysis. | 4h | [Python](https://www.datacamp.com/courses/intro-to-python-for-data-science), [R](https://www.datacamp.com/courses/free-introduction-to-r) |
+| Introduction to SQL | Data acquisition & querying | Learn to query databases using SELECT, WHERE, and JOIN. | 2h | [Link](https://www.datacamp.com/courses/introduction-to-sql) |
+| Introduction to Data Science | Data literacy | Understand the data science workflow, roles, and tools. | 2h | [Link](https://www.datacamp.com/courses/data-science-for-everyone) |
+| Understanding Data Ethics | Ethical use of data | Explore responsible data use, privacy, and fairness. | 1h | [Link](https://www.datacamp.com/courses/data-ethics) |
+| Communicating Data Insights | Data communication | Learn how to present findings clearly to stakeholders. | 2h | [Link](https://www.datacamp.com/courses/communicating-data-insights) |
+| Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
+
+## Track 2: New to Role – Intermediate Level
+
+**Estimated Total Duration**: \~14 hours
+
+| Course | UKSA/GSG Competency | Description | Duration | Link |
+|---------------|---------------|---------------|---------------|---------------|
+| Intermediate Python OR R | Programming logic & control | Learn loops, conditionals, and functions to build more complex scripts. | 4h | [Python](https://www.datacamp.com/courses/intermediate-python), [R](https://www.datacamp.com/courses/intermediate-r) |
+| Exploratory Data Analysis in Python OR R | Data exploration & validation | Learn how to summarize, visualize, and interpret data distributions. | 3h | [Python](https://www.datacamp.com/courses/exploratory-data-analysis-in-python), [R](https://www.datacamp.com/courses/exploratory-data-analysis-in-r) |
+| Joining Data in SQL | Data integration | Learn INNER JOIN, LEFT JOIN, and UNION to combine datasets. | 2h | [Link](https://www.datacamp.com/courses/joining-data-in-sql) |
+| Introduction to Git | Reproducibility | Learn version control basics to track and share code. | 2h | [Link](https://www.datacamp.com/courses/introduction-to-git) |
+| Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
+
+## Track 3: New to Role – High Technical Skill
+
+**Estimated Total Duration**: \~15 hours
+
+| Course | UKSA/GSG Competency | Description | Duration | Link |
+|---------------|---------------|---------------|---------------|---------------|
+| Machine Learning Fundamentals in Python OR R | Advanced analysis | Learn supervised learning, model training, and evaluation. | 3h | [Python](https://www.datacamp.com/tracks/machine-learning-fundamentals-with-python), [R](https://www.datacamp.com/courses/machine-learning-in-r) |
+| Feature Engineering in Python OR R | Model improvement | Learn how to transform raw data into features for better models. | 2h | [Python](https://www.datacamp.com/courses/feature-engineering-for-machine-learning), [R](https://www.datacamp.com/courses/feature-engineering-in-r) |
+| Data Cleaning in Python OR R | Data quality | Learn techniques to handle missing, inconsistent, and messy data. | 2h | [Python](https://www.datacamp.com/courses/cleaning-data-in-python), [R](https://www.datacamp.com/courses/data-cleaning-in-r) |
+| Data Engineering for Everyone | Data pipelines | Understand the basics of data engineering and ETL workflows. | 2h | [Link](https://www.datacamp.com/courses/data-engineering-for-everyone) |
+| Advanced SQL | Complex querying | Learn subqueries, window functions, and performance tuning. | 3h | [Link](https://www.datacamp.com/courses/advanced-sql) |
+| Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
+
+## Track 4: Experienced – Low Technical Skill
+
+**Estimated Total Duration**: \~16 hours
+
+| Course | UKSA/GSG Competency | Description | Duration | Link |
+|---------------|---------------|---------------|---------------|---------------|
+| Introduction to Python OR R | Programming fundamentals | Learn basic syntax, data types, and operations. | 4h | [Python](https://www.datacamp.com/courses/intro-to-python-for-data-science), [R](https://www.datacamp.com/courses/free-introduction-to-r) |
+| Introduction to Power BI | Data visualization | Learn how to build dashboards and reports using Power BI. | 3h | [Link](https://www.datacamp.com/courses/introduction-to-power-bi) |
+| Communicating Data Insights | Data communication | Learn how to present findings clearly to stakeholders. | 2h | [Link](https://www.datacamp.com/courses/communicating-data-insights) |
+| Understanding Prompt Engineering | AI literacy | Learn how to design effective prompts for generative AI tools. | 1.5h | [Link](https://www.datacamp.com/courses/understanding-prompt-engineering) |
+| Introduction to Data Ethics | Ethical use of data | Explore responsible data use, privacy, and fairness. | 1h | [Link](https://www.datacamp.com/courses/data-ethics) |
+| Introduction to SQL | Data acquisition | Learn to query databases using SELECT, WHERE, and JOIN. | 2h | [Link](https://www.datacamp.com/courses/introduction-to-sql) |
+| Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
+
+## Track 5: Experienced – Intermediate Technical Skill
+
+**Estimated Total Duration**: \~18 hours
+
+| Course | UKSA/GSG Competency | Description | Duration | Link |
+|---------------|---------------|---------------|---------------|---------------|
+| Intermediate Python OR R | Programming logic | Learn loops, conditionals, and functions. | 4h | [Python](https://www.datacamp.com/courses/intermediate-python), [R](https://www.datacamp.com/courses/intermediate-r) |
+| Exploratory Data Analysis in Python OR R | Data exploration | Learn how to summarize, visualize, and interpret data. | 3h | [Python](https://www.datacamp.com/courses/exploratory-data-analysis-in-python), [R](https://www.datacamp.com/courses/exploratory-data-analysis-in-r) |
+| Introduction to Git | Reproducibility | Learn version control basics. | 2h | [Link](https://www.datacamp.com/courses/introduction-to-git) |
+| Data Cleaning in Python OR R | Data quality | Handle missing and messy data. | 2h | [Python](https://www.datacamp.com/courses/cleaning-data-in-python), [R](https://www.datacamp.com/courses/data-cleaning-in-r) |
+| Data Ethics and Bias | Responsible analysis | Understand bias and fairness in data work. | 2h | [Link](https://www.datacamp.com/courses/data-ethics-and-bias) |
+| SQL for Data Analysis | Analytical querying | Learn to extract insights from databases. | 3h | [Link](https://www.datacamp.com/courses/sql-for-data-analysis) |
+| Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
+
+## Track 6: Experienced – High Technical Skill
+
+**Estimated Total Duration**: \~20 hours
+
+| Course | UKSA/GSG Competency | Description | Duration | Link |
+|---------------|---------------|---------------|---------------|---------------|
+| Machine Learning Fundamentals in Python OR R | Advanced modelling | Learn supervised learning, model training, and evaluation. | 3h | [Python](https://www.datacamp.com/tracks/machine-learning-fundamentals-with-python), [R](https://www.datacamp.com/courses/machine-learning-in-r) |
+| Feature Engineering in Python OR R | Model improvement | Transform raw data into features. | 2h | [Python](https://www.datacamp.com/courses/feature-engineering-for-machine-learning), [R](https://www.datacamp.com/courses/feature-engineering-in-r) |
+| Advanced SQL | Complex querying | Learn subqueries, window functions, and performance tuning. | 3h | [Link](https://www.datacamp.com/courses/advanced-sql) |
+| Data Engineering for Everyone | Data pipelines | Understand ETL workflows and data infrastructure. | 2h | [Link](https://www.datacamp.com/courses/data-engineering-for-everyone) |
+| Git and Version Control | Reproducibility | Learn branching, merging, and collaboration. | 2h | [Link](https://www.datacamp.com/courses/git-and-version-control) |
+| Data Ethics and Privacy | Responsible data use | Explore privacy, consent, and ethical frameworks. | 2h | [Link](https://www.datacamp.com/courses/data-ethics-and-privacy) |
+| Building Dashboards in Power BI | Visual storytelling | Learn to create interactive dashboards. | 2h | [Link](https://www.datacamp.com/courses/building-dashboards-in-power-bi) |
+| Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
+
+## Track 7: One Big Thing – AI for All: A Headstart!
+
+**Estimated Total Duration**: \~6–8 hours
+
+| Course | Description | Duration | Link |
+|-----------------|--------------------|-----------------|-----------------|
+| Understanding AI | Learn what AI is, how it works, and where it’s used. | 2h | [Link](https://www.datacamp.com/courses/understanding-artificial-intelligence) |
+| Introduction to Machine Learning | Understand ML concepts like supervised learning and model evaluation. | 2h | [Link](https://www.datacamp.com/courses/understanding-machine-learning) |
+| Understanding Prompt Engineering | Learn how to design effective prompts for generative AI tools. | 1.5h | [Link](https://www.datacamp.com/courses/understanding-prompt-engineering) |
+| AI Ethics | Explore fairness, transparency, and responsible AI use. | 1h | [Link](https://www.datacamp.com/courses/ai-ethics) |
+| ChatGPT for Data Analysis | Learn how to use ChatGPT for data tasks. | 1h | [Link](https://www.datacamp.com/courses/understanding-chatgpt) |
+| AI for Decision-Making | Understand how AI supports policy and operational decisions. | 1h | [Link](https://www.datacamp.com/courses/ai-business-fundamentals) |

--- a/learning-development/datacamp-tracks.qmd
+++ b/learning-development/datacamp-tracks.qmd
@@ -7,13 +7,25 @@ format: html
 
 ---
 
-This page contains a tailored set of learning paths designed to support your development as an analyst in the Department for Education (DfE). These tracks draw on DataCamp's extensive course offerings to build competencies aligned with the Government Statistical Service (GSG) framework.
+Our analytical L&D offer includes full enterprise access to [Datacamp](https://www.datacamp.com/). This page contains a tailored set of DataCamp learning paths designed to support your development as an analyst in the Department for Education (DfE).
 
-Each track is tailored to different levels of technical skills and experience, helping you decide which track would be best for you. You'll find estimated duration per course and per track to help you plan your time, and a special AI for All track to get everyone up to speed on foundational AI concepts. Use this page to identify the track that best fits your current goals and needs and head over to [Datacamp](https://www.datacamp.com/) to start learning!
+## What is DataCamp? 
+
+DataCamp is an online learning platform focused on data and analytics skills. It offers over 400 interactive courses across Python, R, SQL, Power BI, Tableau, machine learning, data engineering, and more. The platform is designed to be hands-on: less theory, more doing. You code directly in the browser, get instant feedback, and can apply your learning through real-world projects and assessments.
+
+## How do I get access to DataCamp? 
+
+If you’d like a license, please email datacamp.requests@education.gov.uk copying your line manager. We expect everyone requesting access to have a development conversation with their manager, outlining how they plan to use - and are using - the platform to support their learning and development, making sure this is captured in their personal L&D plan.
 
 ---
 
-# Summary of Learning Tracks
+## What are learning tracks? 
+
+Learning tracks are sets of courses put together using DataCamp to help you build the right skills. These tracks draw on DataCamp's extensive course offerings to build competencies aligned with the Government Statistical Service (GSG) framework.
+
+Each track is tailored to different levels of technical skills and experience, helping you decide which track would be best for you. You'll find estimated duration per course and per track to help you plan your time, and a special AI for All track to get everyone up to speed on foundational AI concepts. Use this page to identify the track that best fits your current goals and needs and head over to [DataCamp](https://www.datacamp.com/) to start learning!
+
+## Summary of Learning Tracks
 
 | Track Name | Target Persona | Estimated Duration |
 |-------------------|------------------------|-----------------------------|
@@ -25,9 +37,9 @@ Each track is tailored to different levels of technical skills and experience, h
 | Experienced – High Technical Skill | Experienced member, high technical skill | \~20 hours |
 | One Big Thing – AI for All: A Headstart! | All staff, introductory AI awareness | \~6–8 hours |
 
-# DataCamp Learning Tracks for Analysts
+## DataCamp Learning Tracks for Analysts
 
-## Track 1: New to Role – Intro Level
+### Track 1: New to Role – Intro Level
 
 **Estimated Total Duration**: \~13 hours
 
@@ -40,7 +52,7 @@ Each track is tailored to different levels of technical skills and experience, h
 | Communicating Data Insights | Data communication | Learn how to present findings clearly to stakeholders. | 2h | [Link](https://www.datacamp.com/courses/communicating-data-insights) |
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
-## Track 2: New to Role – Intermediate Level
+### Track 2: New to Role – Intermediate Level
 
 **Estimated Total Duration**: \~14 hours
 
@@ -52,7 +64,7 @@ Each track is tailored to different levels of technical skills and experience, h
 | Introduction to Git | Reproducibility | Learn version control basics to track and share code. | 2h | [Link](https://www.datacamp.com/courses/introduction-to-git) |
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
-## Track 3: New to Role – High Technical Skill
+### Track 3: New to Role – High Technical Skill
 
 **Estimated Total Duration**: \~15 hours
 
@@ -65,7 +77,7 @@ Each track is tailored to different levels of technical skills and experience, h
 | Advanced SQL | Complex querying | Learn subqueries, window functions, and performance tuning. | 3h | [Link](https://www.datacamp.com/courses/advanced-sql) |
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
-## Track 4: Experienced – Low Technical Skill
+### Track 4: Experienced – Low Technical Skill
 
 **Estimated Total Duration**: \~16 hours
 
@@ -79,7 +91,7 @@ Each track is tailored to different levels of technical skills and experience, h
 | Introduction to SQL | Data acquisition | Learn to query databases using SELECT, WHERE, and JOIN. | 2h | [Link](https://www.datacamp.com/courses/introduction-to-sql) |
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
-## Track 5: Experienced – Intermediate Technical Skill
+### Track 5: Experienced – Intermediate Technical Skill
 
 **Estimated Total Duration**: \~18 hours
 
@@ -93,7 +105,7 @@ Each track is tailored to different levels of technical skills and experience, h
 | SQL for Data Analysis | Analytical querying | Learn to extract insights from databases. | 3h | [Link](https://www.datacamp.com/courses/sql-for-data-analysis) |
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
-## Track 6: Experienced – High Technical Skill
+### Track 6: Experienced – High Technical Skill
 
 **Estimated Total Duration**: \~20 hours
 
@@ -108,7 +120,7 @@ Each track is tailored to different levels of technical skills and experience, h
 | Building Dashboards in Power BI | Visual storytelling | Learn to create interactive dashboards. | 2h | [Link](https://www.datacamp.com/courses/building-dashboards-in-power-bi) |
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
-## Track 7: One Big Thing – AI for All: A Headstart!
+### Track 7: One Big Thing – AI for All: A Headstart!
 
 **Estimated Total Duration**: \~6–8 hours
 

--- a/learning-development/datacamp-tracks.qmd
+++ b/learning-development/datacamp-tracks.qmd
@@ -124,7 +124,7 @@ You'll find estimated duration per course and per track to help you plan your ti
 
 ### Track 7: experienced – high technical skill
 
-**Estimated total duration**: \~20 hours
+**Estimated total duration**: \~20-22 hours
 
 | Course | UKSA/GSG Competency | Description | Duration | Link |
 |---------------|---------------|---------------|---------------|---------------|

--- a/learning-development/datacamp-tracks.qmd
+++ b/learning-development/datacamp-tracks.qmd
@@ -98,7 +98,7 @@ You'll find estimated duration per course and per track to help you plan your ti
 
 **Estimated total duration**: \~16 hours
 
-| Course | UKSA/GSG Competency | Description | Duration | Link |
+| Course | UKSA / GSG Competency | Description | Duration | Link |
 |---------------|---------------|---------------|---------------|---------------|
 | Introduction to Python OR R | Programming fundamentals | Learn basic syntax, data types, and operations. | 4h | [Python](https://www.datacamp.com/courses/intro-to-python-for-data-science), [R](https://www.datacamp.com/courses/free-introduction-to-r) |
 | Introduction to Power BI | Data visualization | Learn how to build dashboards and reports using Power BI. | 3h | [Link](https://www.datacamp.com/courses/introduction-to-power-bi) |

--- a/learning-development/datacamp-tracks.qmd
+++ b/learning-development/datacamp-tracks.qmd
@@ -68,7 +68,7 @@ Each track is tailored to different levels of technical skills and experience, h
 
 **Estimated total duration**: \~15 hours
 
-| Course | UKSA/GSG Competency | Description | Duration | Link |
+| Course | UKSA / GSG Competency | Description | Duration | Link |
 |---------------|---------------|---------------|---------------|---------------|
 | Machine Learning Fundamentals in Python OR R | Advanced analysis | Learn supervised learning, model training, and evaluation. | 3h | [Python](https://www.datacamp.com/tracks/machine-learning-fundamentals-with-python), [R](https://www.datacamp.com/courses/machine-learning-in-r) |
 | Feature Engineering in Python OR R | Model improvement | Learn how to transform raw data into features for better models. | 2h | [Python](https://www.datacamp.com/courses/feature-engineering-for-machine-learning), [R](https://www.datacamp.com/courses/feature-engineering-in-r) |

--- a/learning-development/datacamp-tracks.qmd
+++ b/learning-development/datacamp-tracks.qmd
@@ -3,7 +3,7 @@ title: "Datacamp learning tracks"
 format: html
 ---
 
-<p class="text-muted">  Learning tracks for analysts looking to upskill using Datacamp </p>
+<p class="text-muted">Learning tracks for analysts looking to upskill using DataCamp</p>
 
 ---
 

--- a/learning-development/datacamp-tracks.qmd
+++ b/learning-development/datacamp-tracks.qmd
@@ -126,7 +126,7 @@ You'll find estimated duration per course and per track to help you plan your ti
 
 **Estimated total duration**: \~20-22 hours
 
-| Course | UKSA/GSG Competency | Description | Duration | Link |
+| Course | UKSA / GSG Competency | Description | Duration | Link |
 |---------------|---------------|---------------|---------------|---------------|
 | Machine Learning Fundamentals in Python OR R | Advanced modelling | Learn supervised learning, model training, and evaluation. | 3h | [Python](https://www.datacamp.com/tracks/machine-learning-fundamentals-with-python), [R](https://www.datacamp.com/courses/machine-learning-in-r) |
 | Feature Engineering in Python OR R | Model improvement | Transform raw data into features. | 2h | [Python](https://www.datacamp.com/courses/feature-engineering-for-machine-learning), [R](https://www.datacamp.com/courses/feature-engineering-in-r) |

--- a/learning-development/datacamp-tracks.qmd
+++ b/learning-development/datacamp-tracks.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Datacamp learning tracks"
+title: "DataCamp learning tracks"
 format: html
 ---
 

--- a/learning-development/datacamp-tracks.qmd
+++ b/learning-development/datacamp-tracks.qmd
@@ -9,7 +9,7 @@ format: html
 
 Our analytical L&D offer includes full enterprise access to [Datacamp](https://www.datacamp.com/), more information on this can be found on the [DfE intranet](https://educationgovuk.sharepoint.com/sites/sarpi/g/SitePages/Accessing-DataCamp.aspx?xsdata=MDV8MDJ8fGY1OWQ3MGYyNWY1MDQ5OTdkZjg5MDhkZGZmNmMxYTBjfGZhZDI3N2M5YzYwYTRkYTFiNWYzYjNiOGIzNGE4MmY5fDB8MHw2Mzg5NDc1NjE5MTUwODA1ODV8VW5rbm93bnxWR1ZoYlhOVFpXTjFjbWwwZVZObGNuWnBZMlY4ZXlKRFFTSTZJbFJsWVcxelgwRlVVRk5sY25acFkyVmZVMUJQVEU5R0lpd2lWaUk2SWpBdU1DNHdNREF3SWl3aVVDSTZJbGRwYmpNeUlpd2lRVTRpT2lKUGRHaGxjaUlzSWxkVUlqb3hNWDA9fDF8TDJOb1lYUnpMekU1T2pBMFptRXdaak5qTFdFeVkyWXRORGd3TmkxaVlqRmxMV0kzTURjellURm1abU0wWkY4ellqSmlNakkzTXkxaFpqSTNMVFE1WTJNdFlURTJNeTB6WmpCa1pURmlNREl5WldaQWRXNXhMbWRpYkM1emNHRmpaWE12YldWemMyRm5aWE12TVRjMU9URTFPVE01TVRJeU5BPT18MDZlMTllOWFjZjljNGE3YzQ3ODUwOGRkZmY2YzFhMGN8NzYzMjdmZmE3Mjk1NGU2NDhjNzhmZmU0NGU2NmZjZGM%3D&sdata=TVo5MXNjd2VvcFNDNkVDZ1YzdGU1VEdSZmw4akhsYi91KzIrdnFQVlAzUT0%3D&ovuser=fad277c9-c60a-4da1-b5f3-b3b8b34a82f9%2CCameron.RACE%40EDUCATION.GOV.UK&OR=Teams-HL&CT=1759168995150&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiI0OS8yNTA4MjgxNzkxMiIsIkhhc0ZlZGVyYXRlZFVzZXIiOmZhbHNlfQ%3D%3D). 
 
-This page contains a tailored set of DataCamp learning paths designed to support your development as an analyst in the Department for Education (DfE).
+This page contains a tailored set of DataCamp learning paths designed to support your development as an analyst in the Department for Education (DfE). The first of these paths is AI for all, which has been developed in alignment with the [One Big Thing 2025 ](https://educationgovuk.sharepoint.com/sites/dfe-home/SitePages/One-Big-Thing-2025.aspx) initiative, which aims to build foundational understanding of artificial intelligence across the Civil Service.
 
 ## What is DataCamp? 
 
@@ -25,23 +25,38 @@ If you’d like a license, please email datacamp.requests@education.gov.uk copyi
 
 Learning tracks are sets of courses put together using DataCamp to help you build the right skills. These tracks draw on DataCamp's extensive course offerings to build competencies aligned with the Government Statistical Service (GSG) framework.
 
-Each track is tailored to different levels of technical skills and experience, helping you decide which track would be best for you. You'll find estimated duration per course and per track to help you plan your time, and a special AI for All track to get everyone up to speed on foundational AI concepts. Use this page to identify the track that best fits your current goals and needs and head over to [DataCamp](https://www.datacamp.com/) to start learning!
+The AI for All track is specially designed to get everyone up to speed on foundational AI concepts, in line with [One Big Thing 2025](https://educationgovuk.sharepoint.com/sites/dfe-home/SitePages/One-Big-Thing-2025.aspx). Each of the remaining tracks are tailored to different levels of technical skills and experience, helping you decide which track would be best for you. 
+
+You'll find estimated duration per course and per track to help you plan your time. Use this page to identify the track that best fits your current goals and needs and head over to [DataCamp](https://www.datacamp.com/) to start learning!
 
 ## Summary of learning tracks
 
 | Track Name | Target Persona | Estimated Duration |
 |-------------------|------------------------|-----------------------------|
+| One Big Thing – AI for All: A Headstart! | All staff, introductory AI awareness | \~6–8 hours |
 | New to Role – Intro Level | New to role, low technical skill | \~13 hours |
 | New to Role – Intermediate Level | New to role, intermediate technical skill | \~14 hours |
 | New to Role – High Technical Skill | New to role, high technical skill | \~15 hours |
 | Experienced – Low Technical Skill | Experienced member, low technical skill | \~16 hours |
 | Experienced – Intermediate Technical Skill | Experienced member, intermediate technical skill | \~18 hours |
 | Experienced – High Technical Skill | Experienced member, high technical skill | \~20 hours |
-| One Big Thing – AI for All: A Headstart! | All staff, introductory AI awareness | \~6–8 hours |
 
-## DataCamp learning tracks for analysts
+## DataCamp learning tracks
 
-### Track 1: new to role – intro level
+### Track 1: One Big Thing – AI for all: a headstart!
+
+**Estimated total duration**: \~6–8 hours
+
+| Course | Description | Duration | Link |
+|-----------------|--------------------|-----------------|-----------------|
+| Understanding AI | Learn what AI is, how it works, and where it’s used. | 2h | [Link](https://www.datacamp.com/courses/understanding-artificial-intelligence) |
+| Introduction to Machine Learning | Understand ML concepts like supervised learning and model evaluation. | 2h | [Link](https://www.datacamp.com/courses/understanding-machine-learning) |
+| Understanding Prompt Engineering | Learn how to design effective prompts for generative AI tools. | 1.5h | [Link](https://www.datacamp.com/courses/understanding-prompt-engineering) |
+| AI Ethics | Explore fairness, transparency, and responsible AI use. | 1h | [Link](https://www.datacamp.com/courses/ai-ethics) |
+| ChatGPT for Data Analysis | Learn how to use ChatGPT for data tasks. | 1h | [Link](https://www.datacamp.com/courses/understanding-chatgpt) |
+| AI for Decision-Making | Understand how AI supports policy and operational decisions. | 1h | [Link](https://www.datacamp.com/courses/ai-business-fundamentals) |
+
+### Track 2: new to role – intro level
 
 **Estimated total duration**: \~13 hours
 
@@ -54,7 +69,7 @@ Each track is tailored to different levels of technical skills and experience, h
 | Communicating Data Insights | Data communication | Learn how to present findings clearly to stakeholders. | 2h | [Link](https://www.datacamp.com/courses/communicating-data-insights) |
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
-### Track 2: new to role – intermediate level
+### Track 3: new to role – intermediate level
 
 **Estimated total duration**: \~14 hours
 
@@ -66,7 +81,7 @@ Each track is tailored to different levels of technical skills and experience, h
 | Introduction to Git | Reproducibility | Learn version control basics to track and share code. | 2h | [Link](https://www.datacamp.com/courses/introduction-to-git) |
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
-### Track 3: new to role – high technical skill
+### Track 4: new to role – high technical skill
 
 **Estimated total duration**: \~15 hours
 
@@ -79,7 +94,7 @@ Each track is tailored to different levels of technical skills and experience, h
 | Advanced SQL | Complex querying | Learn subqueries, window functions, and performance tuning. | 3h | [Link](https://www.datacamp.com/courses/advanced-sql) |
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
-### Track 4: experienced – low technical skill
+### Track 5: experienced – low technical skill
 
 **Estimated total duration**: \~16 hours
 
@@ -93,7 +108,7 @@ Each track is tailored to different levels of technical skills and experience, h
 | Introduction to SQL | Data acquisition | Learn to query databases using SELECT, WHERE, and JOIN. | 2h | [Link](https://www.datacamp.com/courses/introduction-to-sql) |
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
-### Track 5: experienced – intermediate technical skill
+### Track 6: experienced – intermediate technical skill
 
 **Estimated total duration**: \~18 hours
 
@@ -107,7 +122,7 @@ Each track is tailored to different levels of technical skills and experience, h
 | SQL for Data Analysis | Analytical querying | Learn to extract insights from databases. | 3h | [Link](https://www.datacamp.com/courses/sql-for-data-analysis) |
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
-### Track 6: experienced – high technical skill
+### Track 7: experienced – high technical skill
 
 **Estimated total duration**: \~20 hours
 
@@ -122,15 +137,4 @@ Each track is tailored to different levels of technical skills and experience, h
 | Building Dashboards in Power BI | Visual storytelling | Learn to create interactive dashboards. | 2h | [Link](https://www.datacamp.com/courses/building-dashboards-in-power-bi) |
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
-### Track 7: One Big Thing – AI for all: a headstart!
 
-**Estimated total duration**: \~6–8 hours
-
-| Course | Description | Duration | Link |
-|-----------------|--------------------|-----------------|-----------------|
-| Understanding AI | Learn what AI is, how it works, and where it’s used. | 2h | [Link](https://www.datacamp.com/courses/understanding-artificial-intelligence) |
-| Introduction to Machine Learning | Understand ML concepts like supervised learning and model evaluation. | 2h | [Link](https://www.datacamp.com/courses/understanding-machine-learning) |
-| Understanding Prompt Engineering | Learn how to design effective prompts for generative AI tools. | 1.5h | [Link](https://www.datacamp.com/courses/understanding-prompt-engineering) |
-| AI Ethics | Explore fairness, transparency, and responsible AI use. | 1h | [Link](https://www.datacamp.com/courses/ai-ethics) |
-| ChatGPT for Data Analysis | Learn how to use ChatGPT for data tasks. | 1h | [Link](https://www.datacamp.com/courses/understanding-chatgpt) |
-| AI for Decision-Making | Understand how AI supports policy and operational decisions. | 1h | [Link](https://www.datacamp.com/courses/ai-business-fundamentals) |

--- a/learning-development/datacamp-tracks.qmd
+++ b/learning-development/datacamp-tracks.qmd
@@ -56,7 +56,7 @@ Each track is tailored to different levels of technical skills and experience, h
 
 **Estimated total duration**: \~14 hours
 
-| Course | UKSA/GSG Competency | Description | Duration | Link |
+| Course | UKSA / GSG Competency | Description | Duration | Link |
 |---------------|---------------|---------------|---------------|---------------|
 | Intermediate Python OR R | Programming logic & control | Learn loops, conditionals, and functions to build more complex scripts. | 4h | [Python](https://www.datacamp.com/courses/intermediate-python), [R](https://www.datacamp.com/courses/intermediate-r) |
 | Exploratory Data Analysis in Python OR R | Data exploration & validation | Learn how to summarize, visualize, and interpret data distributions. | 3h | [Python](https://www.datacamp.com/courses/exploratory-data-analysis-in-python), [R](https://www.datacamp.com/courses/exploratory-data-analysis-in-r) |

--- a/learning-development/datacamp-tracks.qmd
+++ b/learning-development/datacamp-tracks.qmd
@@ -7,7 +7,9 @@ format: html
 
 ---
 
-Our analytical L&D offer includes full enterprise access to [Datacamp](https://www.datacamp.com/). This page contains a tailored set of DataCamp learning paths designed to support your development as an analyst in the Department for Education (DfE).
+Our analytical L&D offer includes full enterprise access to [Datacamp](https://www.datacamp.com/), more information on this can be found on the [DfE intranet](https://educationgovuk.sharepoint.com/sites/sarpi/g/SitePages/Accessing-DataCamp.aspx?xsdata=MDV8MDJ8fGY1OWQ3MGYyNWY1MDQ5OTdkZjg5MDhkZGZmNmMxYTBjfGZhZDI3N2M5YzYwYTRkYTFiNWYzYjNiOGIzNGE4MmY5fDB8MHw2Mzg5NDc1NjE5MTUwODA1ODV8VW5rbm93bnxWR1ZoYlhOVFpXTjFjbWwwZVZObGNuWnBZMlY4ZXlKRFFTSTZJbFJsWVcxelgwRlVVRk5sY25acFkyVmZVMUJQVEU5R0lpd2lWaUk2SWpBdU1DNHdNREF3SWl3aVVDSTZJbGRwYmpNeUlpd2lRVTRpT2lKUGRHaGxjaUlzSWxkVUlqb3hNWDA9fDF8TDJOb1lYUnpMekU1T2pBMFptRXdaak5qTFdFeVkyWXRORGd3TmkxaVlqRmxMV0kzTURjellURm1abU0wWkY4ellqSmlNakkzTXkxaFpqSTNMVFE1WTJNdFlURTJNeTB6WmpCa1pURmlNREl5WldaQWRXNXhMbWRpYkM1emNHRmpaWE12YldWemMyRm5aWE12TVRjMU9URTFPVE01TVRJeU5BPT18MDZlMTllOWFjZjljNGE3YzQ3ODUwOGRkZmY2YzFhMGN8NzYzMjdmZmE3Mjk1NGU2NDhjNzhmZmU0NGU2NmZjZGM%3D&sdata=TVo5MXNjd2VvcFNDNkVDZ1YzdGU1VEdSZmw4akhsYi91KzIrdnFQVlAzUT0%3D&ovuser=fad277c9-c60a-4da1-b5f3-b3b8b34a82f9%2CCameron.RACE%40EDUCATION.GOV.UK&OR=Teams-HL&CT=1759168995150&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiI0OS8yNTA4MjgxNzkxMiIsIkhhc0ZlZGVyYXRlZFVzZXIiOmZhbHNlfQ%3D%3D). 
+
+This page contains a tailored set of DataCamp learning paths designed to support your development as an analyst in the Department for Education (DfE).
 
 ## What is DataCamp? 
 

--- a/learning-development/datacamp-tracks.qmd
+++ b/learning-development/datacamp-tracks.qmd
@@ -9,7 +9,7 @@ format: html
 
 This page contains a tailored set of learning paths designed to support your development as an analyst in the Department for Education (DfE). These tracks draw on DataCamp's extensive course offerings to build competencies aligned with the Government Statistical Service (GSG) framework.
 
-Each track is tailored to different levels of technical skills and career stage, helping you decide which track would be best for you. You'll find estimated duration to help you plan your time, and a special AI for All track to get everyone up to speed on foundational AI concepts. Use this page to identify the track that best fits your current goals and needs and head over to [Datacamp](https://www.datacamp.com/) to start learning!
+Each track is tailored to different levels of technical skills and experience, helping you decide which track would be best for you. You'll find estimated duration to help you plan your time, and a special AI for All track to get everyone up to speed on foundational AI concepts. Use this page to identify the track that best fits your current goals and needs and head over to [Datacamp](https://www.datacamp.com/) to start learning!
 
 ---
 

--- a/learning-development/datacamp-tracks.qmd
+++ b/learning-development/datacamp-tracks.qmd
@@ -134,7 +134,7 @@ You'll find estimated duration per course and per track to help you plan your ti
 | Data Engineering for Everyone | Data pipelines | Understand ETL workflows and data infrastructure. | 2h | [Link](https://www.datacamp.com/courses/data-engineering-for-everyone) |
 | Git and Version Control | Reproducibility | Learn branching, merging, and collaboration. | 2h | [Link](https://www.datacamp.com/courses/git-and-version-control) |
 | Data Ethics and Privacy | Responsible data use | Explore privacy, consent, and ethical frameworks. | 2h | [Link](https://www.datacamp.com/courses/data-ethics-and-privacy) |
-| Building Dashboards in Power BI | Visual storytelling | Learn to create interactive dashboards. | 2h | [Link](https://www.datacamp.com/courses/building-dashboards-in-power-bi) |
+| Building Dashboards in Power BI OR R Shiny OR Python| Visual storytelling | Learn to create interactive dashboards. | 2h | [Power BI](https://www.datacamp.com/courses/building-dashboards-in-power-bi), [R Shiny](https://app.datacamp.com/learn/courses/building-web-applications-with-shiny-in-r), [Python](https://app.datacamp.com/learn/courses/building-dashboards-with-dash-and-plotly)|
 | Data Storytelling | Insight presentation | Learn narrative techniques to make data compelling. | 2h | [Link](https://www.datacamp.com/courses/data-storytelling) |
 
 


### PR DESCRIPTION
## Overview of changes

Adding in the new Datacamp tracks content, designed to support Analysts' development. The page sets out 6 different tracks - by experience and skill level, plus an AI for all track. 

## Why are these changes being made?
This page means the tracks content developed by Sean is more easily accessible to all analysts in DfE. This should save analysts time by directing to the right Datacamp courses for them, as well as giving them direction in where to go after their current course or track is complete. 

## Detailed description of changes
- Added the Datacamp tracks page as designed by Sean 
- Added the page to quarto,yml 
- Added a link to the front page by adding to the index.yml 

## Issue ticket number/s and link

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
