### PR TITLE
ODBC/DBI page update for personal clusters and SQL warehouses:

### DIFF
--- a/ADA/databricks_rstudio_personal_cluster.qmd
+++ b/ADA/databricks_rstudio_personal_cluster.qmd
@@ -238,13 +238,27 @@ library(DBI)
 
 con <- DBI::dbConnect(
   odbc::databricks(),
-  httpPath = Sys.getenv("DATABRICKS_CLUSTER_PATH")
+  httpPath = Sys.getenv("DATABRICKS_CLUSTER_PATH"),
+  useNativeQuery = FALSE #required for dbWriteTable to work
 )
-#Tell odbc which catalog to use
-dbExecute(con, "USE CATALOG catalog_40_copper_proj_fe_skills_statistics_dev;")
 
-# dbGetQuery should be used for SELECT statements only
-dbGetQuery(con, "SELECT * FROM mtcars")
+#dbExecute should be used for commands which don't return any data
+#Tell odbc which catalog to use
+dbExecute(con, "USE CATALOG catalog_40_copper_analyst_training;")
+
+#Tell odbc which schema to use
+dbExecute(con, "USE steam;")
+
+#dbGetQuery should be used for queries that return results
+#Show the tables in the selected catalog / schema
+dbGetQuery(con, "SHOW TABLES;")
+
+#Select data from a table
+dbGetQuery(con, "SELECT * FROM games_description;")
+
+#you can also get data from tables from any catalog / schema you have access to 
+#using the three-level namespace
+dbGetQuery(con, "SELECT * FROM catalog_40_copper_analyst_training.steam.games_description;")
 ```
 
 ------------------------------------------------------------------------

--- a/ADA/databricks_rstudio_sql_warehouse.qmd
+++ b/ADA/databricks_rstudio_sql_warehouse.qmd
@@ -198,13 +198,27 @@ library(DBI)
 
 con <- DBI::dbConnect(
   odbc::databricks(),
-  httpPath = Sys.getenv("DATABRICKS_SQL_PATH")
+  httpPath = Sys.getenv("DATABRICKS_SQL_PATH"),
+  useNativeQuery = FALSE #required for dbWriteTable to work
 )
-#Tell odbc which catalog to use
-dbExecute(con, "USE CATALOG catalog_40_copper_proj_fe_skills_statistics_dev;")
 
-# dbGetQuery should be used for SELECT statements only
-dbGetQuery(con, "SELECT * FROM mtcars")
+#dbExecute should be used for commands which don't return any data
+#Tell odbc which catalog to use
+dbExecute(con, "USE CATALOG catalog_40_copper_analyst_training;")
+
+#Tell odbc which schema to use
+dbExecute(con, "USE steam;")
+
+#dbGetQuery should be used for queries that return results
+#Show the tables in the selected catalog / schema
+dbGetQuery(con, "SHOW TABLES;")
+
+#Select data from a table
+dbGetQuery(con, "SELECT * FROM games_description;")
+
+#you can also get data from tables from any catalog / schema you have access to 
+#using the three-level namespace
+dbGetQuery(con, "SELECT * FROM catalog_40_copper_analyst_training.steam.games_description;")
 ```
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
## Overview of changes

Added the `useNativeQuery=FALSE` argument to the `dbConnect()` function which is required for writing tables to databricks and added some example SQL statements that analysts can try using the universally read-only accessible catalog_40_copper_analyst_guide catalog I set up for training/practice purposes. 



## Why are these changes being made?

The `dbWriteTable()` function using the odbc/DBI packages doesn't work as expected without the argument `useNativeQuery=FALSE`. This question has become quite common on the ADA Support teams channel so hopefully this will head-off some of these queries.

## Detailed description of changes
In the files `databricks_rstudio_personal_cluster.qmd`  and `databricks_rstudio_sql_warehouse.qmd`:

-Added reference to the universally accessible catalog_40_copper_analyst_training 
-Added commands to set the active catalog and schema 
-Added command to show tables within the active catalog / schema 
-Added select statement using table name in the active catalog / schema 
-Added select statement using three-level namespace


## Issue ticket number/s and link

#211 : https://github.com/dfe-analytical-services/analysts-guide/issues/211
#177 : https://github.com/dfe-analytical-services/analysts-guide/issues/177

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
