### PR TITLE
Remove hyphen from instances of state funded

### DIFF
--- a/statistics-production/ud.qmd
+++ b/statistics-production/ud.qmd
@@ -1202,9 +1202,9 @@ a single category under phase_type_grouping:
 
 | phase_type_grouping                |
 |------------------------------------|
-| State-funded primary               |
-| State-funded secondary             |
-| State-funded alternative provision |
+| State funded primary               |
+| State funded secondary             |
+| State funded alternative provision |
 | Special                            |
 | All schools                        |
 


### PR DESCRIPTION
## Overview of changes

We had some inconsistency in the use of hyphens in school types containing state funded. The API teams have started publishing data primarily with no hyphen, so switching Analysts Guide open data standards to match. 

## Why are these changes being made?

Data consistency and clarity

## Detailed description of changes

## Issue ticket number/s and link

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
