### PR TITLE
Adding in alt text checker

### DIFF
--- a/.github/workflows/alt_text_check.yml
+++ b/.github/workflows/alt_text_check.yml
@@ -1,0 +1,58 @@
+on:
+  workflow_dispatch:
+
+name: test-coverage.yaml
+
+permissions: read-all
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::covr, any::xml2
+          needs: coverage
+
+      - name: Test coverage
+        run: |
+          cov <- covr::package_coverage(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+          )
+          print(cov)
+          covr::to_cobertura(cov)
+        shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v5
+        with:
+          # Fail if error if not on PR, or if on PR and token is given
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          files: ./cobertura.xml
+          plugins: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package

--- a/.github/workflows/alt_text_check.yml
+++ b/.github/workflows/alt_text_check.yml
@@ -23,36 +23,5 @@ jobs:
           extra-packages: any::covr, any::xml2
           needs: coverage
 
-      - name: Test coverage
-        run: |
-          cov <- covr::package_coverage(
-            quiet = FALSE,
-            clean = FALSE,
-            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
-          )
-          print(cov)
-          covr::to_cobertura(cov)
-        shell: Rscript {0}
-
-      - uses: codecov/codecov-action@v5
-        with:
-          # Fail if error if not on PR, or if on PR and token is given
-          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
-          files: ./cobertura.xml
-          plugins: noop
-          disable_search: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Show testthat output
-        if: always()
-        run: |
-          ## --------------------------------------------------------------------
-          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
-        shell: bash
-
-      - name: Upload test results
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-test-failures
-          path: ${{ runner.temp }}/package
+      - name: Run R script file
+        run: Rscript .github/workflows/workflow_scripts/alt_text_checker.R

--- a/.github/workflows/alt_text_check.yml
+++ b/.github/workflows/alt_text_check.yml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
 
-name: test-coverage.yaml
+name: alt-text-check.yaml
 
 permissions: read-all
 

--- a/.github/workflows/workflow_scripts/alt_text_checker.R
+++ b/.github/workflows/workflow_scripts/alt_text_checker.R
@@ -1,0 +1,94 @@
+get_file_content <- function(file_name){
+  
+  # Try fetching the content
+  tryCatch({
+    # Read the file using readLines()
+    file_content <- readLines(file_name)
+  })
+  
+  return(file_content)
+  
+}
+
+check_all_have_alt_text <- function(v) {
+  if(length(v) >4){
+    boolean_1 <- v == "a"
+    boolean_2 <- v == "a" &
+      v[-1] == "b" &
+      v[-c(1:2)] == "c" &
+      v[-c(1:3)] == "d" &
+      v[-c(1:4)] == "e"
+    result <- identical(boolean_1,boolean_2)
+  }
+  else{
+    if ("a" %in% v){
+      result <- FALSE
+    }else{
+      result <- TRUE
+    }
+  }
+  return(result)
+}
+
+
+check_line_for_alt_text <- function(line){
+  
+  exclamation_open_bracket_loc <- gregexpr("\\!+(\\s*\\[|\\[)",line)[[1]]
+  string_dataframe <- data.frame(character = rep("a",length(exclamation_open_bracket_loc)),
+                                 position = exclamation_open_bracket_loc)
+  
+  close_sq_bracket_open_rd_loc <- gregexpr("\\]+(\\s*\\(|\\()",line)[[1]]
+  string_dataframe <- rbind(string_dataframe,
+                            data.frame(character = rep("b",length(close_sq_bracket_open_rd_loc)),
+                                       position = close_sq_bracket_open_rd_loc))
+  
+  close_rd_bracket_open_cly_loc <- gregexpr("\\)+(\\s*\\{|\\{)",line)[[1]]
+  string_dataframe <- rbind(string_dataframe,
+                            data.frame(character = rep("c",length(close_rd_bracket_open_cly_loc)),
+                                       position = close_rd_bracket_open_cly_loc))
+  
+  alt_text_loc <- gregexpr("alt-text",line)[[1]]
+  string_dataframe <- rbind(string_dataframe,
+                            data.frame(character = rep("d",length(alt_text_loc)),
+                                       position = alt_text_loc))
+                            
+  close_cly_bracket_loc <- gregexpr("\\}",line)[[1]]
+  string_dataframe <- rbind(string_dataframe,
+                            data.frame(character = rep("e",length(close_cly_bracket_loc)),
+                                       position = close_cly_bracket_loc))
+  
+  
+  string_dataframe <- string_dataframe |> dplyr::arrange(position) |> dplyr::filter(position != -1)
+  
+  
+  string_vector <- string_dataframe$character
+  
+  return(check_all_have_alt_text(string_vector))
+    
+}
+
+check_file_for_alt_text <- function(the_file){
+  
+  file_content <- get_file_content(the_file)
+  
+  errors <- c()
+  for(line in 1:length(file_content)){
+    if(!check_line_for_alt_text(file_content[line])){
+      errors <- c(errors,line)
+    }
+  }
+  return(errors)
+}
+
+check_project_for_alt_text <- function(){
+  errors <- list()
+  markdown_files <- list.files(pattern = "\\.qmd$", full.names = TRUE, recursive = TRUE)
+  
+  for(file in markdown_files){
+    print(file)
+    errors[[file]] <- check_file_for_alt_text(file)
+  }
+  print(errors)
+}
+
+check_project_for_alt_text()

--- a/.github/workflows/workflow_scripts/alt_text_checker.R
+++ b/.github/workflows/workflow_scripts/alt_text_checker.R
@@ -1,15 +1,17 @@
+# Pulls in the content of the file, line by line, each line being a string
 get_file_content <- function(file_name){
   
   # Try fetching the content
   tryCatch({
     # Read the file using readLines()
-    file_content <- readLines(file_name)
+    file_content <- readLines(file_name, warn = FALSE)
   })
   
   return(file_content)
   
 }
 
+# Checks that any grouping ![](){} has either alt-text or fig-alt in the brackets
 check_all_have_alt_text <- function(v) {
   if(length(v) >4){
     boolean_1 <- v == "a"
@@ -30,7 +32,7 @@ check_all_have_alt_text <- function(v) {
   return(result)
 }
 
-
+# Checks a line for positions of ![ := a, ]( := b, ){ := c, alt-text or fig-alt := d, and } := e, then arranges them in terms of position in the line
 check_line_for_alt_text <- function(line){
   
   exclamation_open_bracket_loc <- gregexpr("\\!+(\\s*\\[|\\[)",line)[[1]]
@@ -47,7 +49,7 @@ check_line_for_alt_text <- function(line){
                             data.frame(character = rep("c",length(close_rd_bracket_open_cly_loc)),
                                        position = close_rd_bracket_open_cly_loc))
   
-  alt_text_loc <- gregexpr("alt-text",line)[[1]]
+  alt_text_loc <- gregexpr("alt-text|fig-alt",line)[[1]]
   string_dataframe <- rbind(string_dataframe,
                             data.frame(character = rep("d",length(alt_text_loc)),
                                        position = alt_text_loc))
@@ -63,10 +65,11 @@ check_line_for_alt_text <- function(line){
   
   string_vector <- string_dataframe$character
   
-  return(check_all_have_alt_text(string_vector))
+  return(suppressWarnings(check_all_have_alt_text(string_vector)))
     
 }
 
+# For each line checks if there's a picture without alt text and spits out the lines where this is the case
 check_file_for_alt_text <- function(the_file){
   
   file_content <- get_file_content(the_file)
@@ -80,6 +83,7 @@ check_file_for_alt_text <- function(the_file){
   return(errors)
 }
 
+# For each qmd file in the project checks them for lines where there is a picture without alt-text
 check_project_for_alt_text <- function(){
   errors <- list()
   markdown_files <- list.files(pattern = "\\.qmd$", full.names = TRUE, recursive = TRUE)
@@ -91,4 +95,5 @@ check_project_for_alt_text <- function(){
   print(errors)
 }
 
+# Runs the above to print out the errors
 check_project_for_alt_text()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,8 @@ formatting, it saves everything in plain Markdown. You can easily switch
 between the visual and source editors to view and edit your content in
 either format.
 
+Note to add an image you can do so the following way: !\[Image Name\] `(path to image)`{fig-alt = "alt text for user"}
+
 #### Adding links (within page, within site, external to site)\]
 
 In Quarto, you can add links using the following Markdown syntax:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,8 @@ formatting, it saves everything in plain Markdown. You can easily switch
 between the visual and source editors to view and edit your content in
 either format.
 
-Note to add an image you can do so the following way: !\[Image Name\] `(path to image)`{fig-alt = "alt text for user"}
+Note to add an image with alternative text in the following way: 
+!\[Image Name\] `(path to image)`{fig-alt = "alt text for user"}
 
 #### Adding links (within page, within site, external to site)\]
 


### PR DESCRIPTION
## Overview of changes
This is a quick PR uploading code to check whether the markdown uses alt-text, it spits out a list of files and line numbers where alt-text is missing.

There is also a yaml script to run this, with a manual trigger, we can alter the trigger as needed.

It doesn't take long to run.

## Why are these changes being made?
Just to provide us of better coverage in terms of accessibility.

## Detailed description of changes
Two scripts added, an R script to run through all the quarto files, find locations where there is something of the form ![x](y){z} but within z there isn't anything beginning alt-text (note as it stands this means you can put in an empty alt-text = "" and it will pass, which isn't great, but I expect that if you've bothered to write it out then you'll have added in alt text, copy and pasting also would include previous alt-text where testing for duplicates isn't sensible in case there is reason to duplicate.

## Issue ticket number/s and link

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
