### PR TITLE
Add paragraph recommending use of raw NSPL data in bronze catalog

### DIFF
--- a/ADA/databricks_medallion_architecture.qmd
+++ b/ADA/databricks_medallion_architecture.qmd
@@ -40,6 +40,14 @@ This layered approach gives you **reproducibility** (you always keep the raw dat
 
 **Example use case:** A daily extract from a school attendance records system lands as CSV files. The Bronze table stores every row from every file, including duplicates, with a timestamp of when each batch was loaded.
 
+### ONS geography data - National Statistics Postcode Lookup (NSPL) dataset
+
+The NSPL data is an example of a dataset used widely across the Department's analytical community. The raw dataset, as published by ONS, has been uploaded to the bronze catalog on Databricks and is available for analysts to access and use. This dataset will be updated quarterly, in sync with regular NSPL releases.
+
+It is recommended that analysts source NSPL data from this table, and subsequently apply any required processing to manipulate the data as needed for their analysis, rather than uploading their own cut of the data into another modelling area. This will ensure analysts are working from the same single source of NSPL data at any point, and will avoid unnecessary duplication of tables within and across catalogs in Databricks.
+
+The raw NSPL data can be found in the `catalog_30_bronze.ons_geography.vw_nspl_[month]_[year]` table in Databricks, where `month` and `year` are the month and year of publication of the dataset in the table.
+
 ---
 
 ## Silver Layer – Cleaned & Conformed

--- a/ADA/databricks_medallion_architecture.qmd
+++ b/ADA/databricks_medallion_architecture.qmd
@@ -46,7 +46,7 @@ The NSPL data is an example of a dataset used widely across the Department's ana
 
 It is recommended that analysts source NSPL data from this table, and subsequently apply any required processing to manipulate the data as needed for their analysis, rather than uploading their own cut of the data into another modelling area. This will ensure analysts are working from the same single source of NSPL data at any point, and will avoid unnecessary duplication of tables within and across catalogs in Databricks.
 
-The raw NSPL data can be found in the `catalog_30_bronze.ons_geography.vw_nspl_[month]_[year]` table in Databricks, where `month` and `year` are the month and year of publication of the dataset in the table.
+The raw NSPL data can be found in the `catalog_30_bronze.ons_geography.vw_nspl_[month]_[year]` table in the `s101p01-dbr-edap-02` workspace on Databricks, where `month` and `year` are the first three letters of the month, and the year, of publication of the dataset in the table.
 
 ---
 


### PR DESCRIPTION
## Overview of changes
Adding guidance to highlight raw ONS NSPL dataset in bronze catalog on Databricks

## Why are these changes being made?
The NSPL dataset is widely used by analysts in DfE, with lots of duplicated cuts of the same data existing across different modelling areas/tables. We & DDaT colleagues wanted a single source of the NSPL dataset for analysts to use to avoid this duplication. The raw dataset has now been uploaded to the bronze catalog by the ADA team, and will be updated quarterly with new releases. We now should add guidance to point analysts to use it.

## Detailed description of changes
Added a paragraph into the Medallion architecture page (as I think this is probably the best place to fit it in) to highlight the raw NSPL dataset and recommend analysts use it rather than creating/uploading their own cuts of the same data to Databricks.

## Issue ticket number/s and link
 Wasn't created as an issue but we have a Jira card: https://dfedigital.atlassian.net/browse/SSU-1580

## Checklist before requesting a review
- [x] I have checked the contributing guidelines
- [x] I have checked for and linked any relevant issues that this may resolve
- [x] I have checked that these changes build locally
- [x] I understand that if merged into main, these changes will be publicly available
